### PR TITLE
Pin to jdk-27+35, a tag that exists, and watch for it moving

### DIFF
--- a/.github/ISSUE_TEMPLATE/wrong.yml
+++ b/.github/ISSUE_TEMPLATE/wrong.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Which JVM
       description: The banner cell prints this, or run `java -Xinternalversion`
-      placeholder: jdk-27-ga, release build, x86-64
+      placeholder: jdk-27+35, release build, x86-64
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 - [ ] `python tools/prosecheck.py .` is clean
 - [ ] No number in the prose was typed by hand
-- [ ] Every source citation is `path:line@jdk-27-ga` and resolves at its recorded hash
+- [ ] Every source citation is `path:line@jdk-27+35` and resolves at its recorded hash
 - [ ] Every specification citation names a section, not a chapter, and the quoted text is in it
 - [ ] Every claim carries a `[JVMS]` or a `[HOTSPOT]` marker, and none of them is guessed
 - [ ] Any claim about what is default, deprecated, preview or in progress carries a date

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -82,6 +82,45 @@ jobs:
               core.info(`filed: ${title}`)
             }
 
+            // 0. The pinned tag still points where it did when we pinned it.
+            // Re tagging is rare and it is the one kind of drift that leaves no
+            // trace: every citation still resolves, every line number is still
+            // there, and every one of them is now against different content.
+            if (pin.jdk_tag_commit) {
+              try {
+                const ref = await github.rest.git.getRef({
+                  owner: 'openjdk', repo: 'jdk', ref: `tags/${pin.jdk_tag}`,
+                })
+                let sha = ref.data.object.sha
+                if (ref.data.object.type === 'tag') {
+                  const annotated = await github.rest.git.getTag({
+                    owner: 'openjdk', repo: 'jdk', tag_sha: sha,
+                  })
+                  sha = annotated.data.object.sha
+                }
+                if (sha !== pin.jdk_tag_commit) {
+                  await file(
+                    `The pinned tag moved: ${pin.jdk_tag} is no longer ${pin.jdk_tag_commit.slice(0, 12)}`,
+                    ['kind/chore', 'priority/p0', 'area/build'],
+                    [
+                      `\`docs/pin.json\` records \`${pin.jdk_tag}\` at \`${pin.jdk_tag_commit}\` and upstream now has it at \`${sha}\`.`,
+                      ``,
+                      `This is the drift that leaves no trace. Every citation still resolves, every line number still exists, and every one of them is now against content nobody checked. Nothing else in this repository can be trusted until the two agree again.`,
+                      ``,
+                      `- [ ] Work out what happened upstream, since a moved tag is unusual enough to need an explanation`,
+                      `- [ ] Re run refcheck against the new commit and list every citation whose surrounding hash changed`,
+                      `- [ ] Regenerate every generated blueprint section and diff it`,
+                      `- [ ] Either update \`jdk_tag_commit\` or move the pin, and say in the commit message which and why`,
+                      ``,
+                      `Filed by \`.github/workflows/pin-watch.yml\`.`,
+                    ],
+                  )
+                }
+              } catch (e) {
+                core.warning(`could not resolve ${pin.jdk_tag}: ${e.message}`)
+              }
+            }
+
             // 1. The pin is still on a release candidate and GA has landed.
             if (pin.jdk_tag !== gaTag && current.includes(gaTag)) {
               await file(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,12 @@ The whole point of this project is that a reader can check everything, so most o
 
 Everything is written against one JDK tag and one specification edition, both recorded in `docs/pin.json`. Nothing anywhere else names a version.
 
+The tag is `jdk-27+35`. It is the release candidate, it is the newest tag in the 27 line on `openjdk/jdk`, and the GA binaries published at jdk.java.net report the same commit it resolves to. The pin is a tag that exists rather than a name for a stage, because a citation is only checkable if the thing it names can be fetched. When `jdk-27-ga` is tagged the pin moves to it, and the first task of that move is confirming the two tags point at the same commit.
+
 Citations come in two forms and CI resolves both.
 
 ```
-src/hotspot/share/oops/markWord.hpp:48@jdk-27-ga
+src/hotspot/share/oops/markWord.hpp:48@jdk-27+35
 JVMS §5.4.3.1@SE25
 ```
 
@@ -21,7 +23,7 @@ Every claim carries a marker. Either `[JVMS]` with the section, or `[HOTSPOT]` w
 
 ```markdown
 The class must be initialized before its first static field access {[JVMS §5.5]}.
-The initialization lock is per class and is implemented as a recursive monitor on the mirror {[HOTSPOT src/hotspot/share/oops/instanceKlass.cpp:1084@jdk-27-ga]}.
+The initialization lock is per class and is implemented as a recursive monitor on the mirror {[HOTSPOT src/hotspot/share/oops/instanceKlass.cpp:1084@jdk-27+35]}.
 ```
 
 Three rules about the markers. When in doubt it is `[HOTSPOT]`, because claiming something is guaranteed when it is not is the failure that harms readers, and claiming something is an implementation detail when it is actually specified merely makes them cautious. A `[JVMS]` marker names the section and not the chapter, so `[JVMS §5.4.3.1]` and never `[JVMS §5]`. And where the two disagree in an interesting way, that disagreement is the lesson, because the best paragraphs in this project are the ones that say the specification permits this, HotSpot does that, OpenJ9 does something else, and here is why it matters to you.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A complete visual teardown of the JVM, taught from zero, where you run a real JDK 27 from a notebook cell and the notebook is running on the machine you are studying.
 
-Pinned to `jdk-27+RC`, moving to `jdk-27-ga` on 15 September 2026.
+Pinned to `jdk-27+35`, the release candidate, moving to `jdk-27-ga` when that tag lands on 15 September 2026.
 
 [![ci](https://github.com/tamnd/jvm-internals/actions/workflows/ci.yml/badge.svg)](https://github.com/tamnd/jvm-internals/actions/workflows/ci.yml) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tamnd/jvm-internals/badge)](https://scorecard.dev/viewer/?uri=github.com/tamnd/jvm-internals)
 

--- a/docs/pin.json
+++ b/docs/pin.json
@@ -1,11 +1,14 @@
 {
-  "jdk_tag": "jdk-27+RC",
+  "jdk_tag": "jdk-27+35",
+  "jdk_tag_commit": "815ff4dc327fe17f2433c7d115a5a503af10f3c4",
+  "jdk_tag_date": "2026-08-19",
+  "jdk_build": "27+35-2325",
   "jdk_ga_tag": "jdk-27-ga",
   "jdk_ga_date": "2026-09-15",
   "jvms_edition": "SE25",
   "jls_edition": "SE25",
   "class_file_major": 69,
-  "citation_suffix": "@jdk-27-ga",
+  "citation_suffix": "@jdk-27+35",
   "spec_citation_suffix": "@SE25",
-  "note": "Every claim, citation, generated blueprint section and shipped JDK in this repository is written against these values. Moving them is a milestone, not a commit. See ROADMAP.md, M6."
+  "note": "Every claim, citation, generated blueprint section and shipped JDK in this repository is written against these values. Moving them is a milestone, not a commit. See ROADMAP.md, M6. jdk-27+35 is the release candidate: it is the newest tag on openjdk/jdk in the 27 line, it resolves to commit 815ff4dc327f, and the GA binaries published at jdk.java.net/27 report that same commit in their release file. When jdk-27-ga is tagged it is expected to point at the same commit, and confirming that is the first task of the pin move."
 }

--- a/tools/prosecheck.py
+++ b/tools/prosecheck.py
@@ -47,7 +47,7 @@ BANNED = re.compile(
     re.IGNORECASE,
 )
 
-# A source citation looks like src/hotspot/share/oops/markWord.hpp:48@jdk-27-ga
+# A source citation looks like src/hotspot/share/oops/markWord.hpp:48@jdk-27+35
 # and a specification citation looks like JVMS 5.4.3.1@SE25. Both are matched on
 # the suffix rather than the whole form, because the whole form is refcheck's
 # job and this is the cheap half that catches a stale tag in a pull request


### PR DESCRIPTION
The pin said `jdk-27+RC`. That is not a tag. There is no `jdk-27+RC` anywhere in `openjdk/jdk`, so every citation written against it would have been unresolvable from the day it was written, and `refcheck` would have found that out somewhere around the third lesson.

## What the tag actually is

The newest tag in the 27 line on `openjdk/jdk` is `jdk-27+35`, tagged 19 August 2026. It resolves to commit `815ff4dc327fe17f2433c7d115a5a503af10f3c4`.

The GA binaries are already published at jdk.java.net/27, ahead of the 15 September GA date. Downloading one and reading its `release` file gives `SOURCE=".:git:815ff4dc327f"`, which is that same commit. So `jdk-27+35` is the release candidate, it is what the published binaries were built from, and it is a name that can be fetched.

That last part is the whole reason to change this. A pin is only worth having if a citation against it can be resolved, and a pin that names a stage rather than a tag cannot be.

## What changed

`docs/pin.json` gets `jdk_tag: "jdk-27+35"` and three new fields: `jdk_tag_commit`, `jdk_tag_date` and `jdk_build`. Recording the commit is not decoration. It is what lets the next section work.

Every citation example in `CONTRIBUTING.md`, `prosecheck.py`, the pull request template and the wrong.yml issue template moves from `@jdk-27-ga` to `@jdk-27+35`, because an example that shows the wrong form is the form people copy. The README pin line now says which stage the tag is and what happens next.

## A new check in pin-watch

Every morning, resolve `jdk-27+35` upstream, dereference the annotated tag, and compare the commit against `jdk_tag_commit`. If they differ, file a P0.

A moved tag is the one kind of upstream drift that leaves no trace. Every citation still resolves. Every line number still exists. Every one of them is now against content nobody checked. `refcheck` hashes the surrounding lines so it would eventually catch the consequences, but it would report them as forty separate mysteries rather than as one cause, and the cause is what you want at seven in the morning.

Re tagging is rare. It is cheap to check and expensive to discover late, which is the shape of thing a daily job is for.

## What did not change

`jdk_ga_tag` stays `jdk-27-ga` and `jdk_ga_date` stays 15 September 2026. The existing pin-watch case that files an issue when GA lands still works unchanged. When it fires, the first task on that issue is confirming `jdk-27-ga` and `jdk-27+35` point at the same commit, which is the normal case and which is now checkable in one command because the commit is written down.

## Checks

- [x] `python tools/prosecheck.py .`
- [x] `python tools/build.py check`
- [x] `actionlint`
- [x] `jdk-27+35` resolves to `815ff4dc327f` through the GitHub API
- [x] The published GA binary reports the same commit in its `release` file
