### PR TITLE
Generate the mark word layout from markWord.hpp instead of typing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,27 @@ jobs:
           diff /tmp/pass2 /tmp/pass3
           echo "three builds, $(wc -l < /tmp/pass1) notebooks, same bytes"
 
+  # Numbers that came out of HotSpot's own headers have to keep coming out of
+  # them. This is a separate job from the notebooks one on purpose: it is the
+  # only thing in CI that reaches out to openjdk/jdk, so when GitHub's raw host
+  # has a bad minute the failure says "the generated file check could not reach
+  # upstream" instead of quietly discrediting the determinism check next door.
+  generated:
+    name: generated files match HotSpot
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+      - name: unit tests
+        run: python tools/test_gen_markword.py
+      - name: the mark word layout is still what is committed
+        run: python tools/gen_markword.py --check
+
   # Workflow files get the same treatment as everything else here. actionlint
   # catches the shell and expression mistakes, zizmor catches the security ones,
   # and the reason both run is that a workflow is the part of a repository
@@ -140,7 +161,10 @@ jobs:
   #     markers       1m   rule 7: every claim carries [JVMS] or [HOTSPOT], and
   #                        at most two unobservable claims per lesson
   #     bpc           6m   bpc build then bpc check, so no generated blueprint
-  #                        section is stale and no coverage item is unowned
+  #                        section is stale and no coverage item is unowned. The
+  #                        first generator, the mark word layout, is already in
+  #                        the generated job above and folds into this one when
+  #                        bpc exists
   #     e0-fast      25m   the tier 0 cells of changed lessons, in the Colab
   #                        parity image. Expensive, and the one that must not be
   #                        cut, because a lesson whose observations quietly

--- a/docs/generated/markword.json
+++ b/docs/generated/markword.json
@@ -1,0 +1,107 @@
+{
+  "generated_by": "tools/gen_markword.py",
+  "source": {
+    "path": "src/hotspot/share/oops/markWord.hpp",
+    "tag": "jdk-27+35",
+    "origin": "https://raw.githubusercontent.com/openjdk/jdk/jdk-27%2B35/src/hotspot/share/oops/markWord.hpp",
+    "sha256": "c249a091cf7dcae455d073a32f29d65b0bf2c1f0b452bc5705b706a6f1aba267",
+    "lines": 318
+  },
+  "word_bits": 64,
+  "fields": [
+    {
+      "name": "lock",
+      "shift": 0,
+      "bits": 2,
+      "mask": "0x0000000000000003",
+      "meaning": "the lock state, and whether a collector has marked or forwarded the object",
+      "defined_at": {
+        "shift": "src/hotspot/share/oops/markWord.hpp:124@jdk-27+35",
+        "bits": "src/hotspot/share/oops/markWord.hpp:116@jdk-27+35"
+      }
+    },
+    {
+      "name": "self_fwd",
+      "shift": 2,
+      "bits": 1,
+      "mask": "0x0000000000000004",
+      "meaning": "set when a collector forwarded the object in place",
+      "defined_at": {
+        "shift": "src/hotspot/share/oops/markWord.hpp:125@jdk-27+35",
+        "bits": "src/hotspot/share/oops/markWord.hpp:117@jdk-27+35"
+      }
+    },
+    {
+      "name": "age",
+      "shift": 3,
+      "bits": 4,
+      "mask": "0x0000000000000078",
+      "meaning": "how many collections the object has survived",
+      "defined_at": {
+        "shift": "src/hotspot/share/oops/markWord.hpp:126@jdk-27+35",
+        "bits": "src/hotspot/share/oops/markWord.hpp:118@jdk-27+35"
+      }
+    },
+    {
+      "name": "valhalla",
+      "shift": 7,
+      "bits": 4,
+      "mask": "0x0000000000000780",
+      "meaning": "reserved for Valhalla, unused today",
+      "defined_at": {
+        "shift": "src/hotspot/share/oops/markWord.hpp:127@jdk-27+35",
+        "bits": "src/hotspot/share/oops/markWord.hpp:119@jdk-27+35"
+      }
+    },
+    {
+      "name": "hash",
+      "shift": 11,
+      "bits": 31,
+      "mask": "0x000003fffffff800",
+      "meaning": "the identity hash, written the first time anything asks for it",
+      "defined_at": {
+        "shift": "src/hotspot/share/oops/markWord.hpp:128@jdk-27+35",
+        "bits": "src/hotspot/share/oops/markWord.hpp:121@jdk-27+35"
+      }
+    },
+    {
+      "name": "klass",
+      "shift": 42,
+      "bits": 22,
+      "mask": "0xfffffc0000000000",
+      "meaning": "the compressed class pointer, present only when UseCompactObjectHeaders is on",
+      "defined_at": {
+        "shift": "src/hotspot/share/oops/markWord.hpp:150@jdk-27+35",
+        "bits": "src/hotspot/share/oops/markWord.hpp:152@jdk-27+35"
+      }
+    }
+  ],
+  "total_field_bits": 64,
+  "lock_states": [
+    {
+      "bits": "00",
+      "name": "locked",
+      "meaning": "a stack lock is held, and the real header is in the lock record"
+    },
+    {
+      "bits": "01",
+      "name": "unlocked",
+      "meaning": "the ordinary state"
+    },
+    {
+      "bits": "10",
+      "name": "monitor",
+      "meaning": "the lock is inflated"
+    },
+    {
+      "bits": "11",
+      "name": "marked",
+      "meaning": "a collector is using the word, and the real header is elsewhere"
+    }
+  ],
+  "diagram_lines": {
+    "legacy": "src/hotspot/share/oops/markWord.hpp:43@jdk-27+35",
+    "compact": "src/hotspot/share/oops/markWord.hpp:47@jdk-27+35"
+  },
+  "note": "The klass field is present only when UseCompactObjectHeaders is on, which is the default on 64 bit platforms from JDK 27. With the flag off, those 22 bits are unused in the mark word and the class pointer is a separate 4 byte field after it. The C++ oopDesc struct declares that field either way, so reading the struct alone will tell you the object has one when it does not."
+}

--- a/tools/gen_markword.py
+++ b/tools/gen_markword.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Generate the object header bit layout from HotSpot's own header file.
+
+The mark word is 64 bits carrying five things at once, and every lesson about object
+layout, locking, identity hash and garbage collection ages has to say where each one
+sits. Those positions are not in the JVMS. They are not in any book that is current.
+They are in `src/hotspot/share/oops/markWord.hpp`, expressed as a chain of constants
+that each define themselves in terms of the one below.
+
+So this reads that file at the pinned tag and works the chain out, rather than a
+person reading it once and typing the numbers into a diagram. A number typed by hand
+is a number that is wrong after the next release and that nobody notices, and the
+positions in this particular file moved twice in the last three releases.
+
+The output is `docs/generated/markword.json`: every field with its shift, its width,
+its mask, and the line of `markWord.hpp` each of those came from. The line numbers
+are what make the citations in a lesson resolvable, and the SHA-256 of the whole file
+is what makes a claim that the file has not changed underneath us checkable.
+
+  python tools/gen_markword.py            regenerate docs/generated/markword.json
+  python tools/gen_markword.py --check    regenerate in memory and fail on a difference
+  python tools/gen_markword.py --print    print the layout as a table
+
+The source is fetched from raw.githubusercontent.com at the tag in docs/pin.json, or
+read from a local OpenJDK checkout when JVX_JDK_SRC points at one, which is what
+makes this work offline and in a build tree.
+
+This is the small, working half of `bpc`. The other half reads the Serviceability
+Agent type database out of a live VM, which is a better source because it is what the
+VM itself believes, and it is a harder one because it needs a process to attach to.
+Both are needed and they check each other. Where they disagree, the disagreement is
+the interesting thing rather than a bug in one of them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+HEADER_PATH = "src/hotspot/share/oops/markWord.hpp"
+RAW = "https://raw.githubusercontent.com/openjdk/jdk/{tag}/{path}"
+
+OUTPUT = pathlib.Path("docs/generated/markword.json")
+
+# `static const int lock_bits = 2;` and `static constexpr int klass_bits = 22;`.
+# Both spellings appear in the file and both mean the same thing here.
+CONSTANT = re.compile(
+    r"^\s*static\s+const(?:expr)?\s+(?:int|uintptr_t)\s+"
+    r"(?P<name>\w+)\s*=\s*(?P<expr>[^;]+);"
+)
+
+# The subset of C++ the constant chain is written in. Anything outside it is a
+# reason to stop rather than to guess.
+LP64_ONLY = re.compile(r"LP64_ONLY\(\s*([^)]*)\s*\)")
+NOT_LP64 = re.compile(r"NOT_LP64\(\s*([^)]*)\s*\)")
+TERNARY = re.compile(r"^(?P<cond>.+?)\?(?P<yes>.+?):(?P<no>.+)$")
+SAFE = re.compile(r"^[\w\s+\-*/()<>=!]*$")
+
+# `BitsPerWord` comes from globalDefinitions.hpp and is 64 on every platform this
+# project targets. It is stated here rather than parsed because it is a property of
+# the build, not of markWord.hpp, and pretending otherwise would be a lie about
+# where the number came from.
+ENVIRONMENT = {"BitsPerWord": 64, "BitsPerByte": 8}
+
+# The fields, least significant first, and the constant that gives each its width.
+# The order is the file's own order and the names are the file's own names.
+FIELDS = [
+    ("lock", "lock_shift", "lock_bits", "the lock state, and whether a collector has marked or forwarded the object"),
+    ("self_fwd", "self_fwd_shift", "self_fwd_bits", "set when a collector forwarded the object in place"),
+    ("age", "age_shift", "age_bits", "how many collections the object has survived"),
+    ("valhalla", "valhalla_reserved_shift", "valhalla_reserved_bits", "reserved for Valhalla, unused today"),
+    ("hash", "hash_shift", "hash_bits", "the identity hash, written the first time anything asks for it"),
+    ("klass", "klass_shift", "klass_bits", "the compressed class pointer, present only when UseCompactObjectHeaders is on"),
+]
+
+LOCK_STATES = [
+    ("00", "locked", "a stack lock is held, and the real header is in the lock record"),
+    ("01", "unlocked", "the ordinary state"),
+    ("10", "monitor", "the lock is inflated"),
+    ("11", "marked", "a collector is using the word, and the real header is elsewhere"),
+]
+
+
+def load_pin(root: pathlib.Path) -> dict:
+    return json.loads((root / "docs" / "pin.json").read_text(encoding="utf-8"))
+
+
+def fetch_header(tag: str) -> tuple[str, str]:
+    """Return the header source and where it came from."""
+    local = os.environ.get("JVX_JDK_SRC")
+    if local:
+        path = pathlib.Path(local) / HEADER_PATH
+        if not path.is_file():
+            raise SystemExit(f"JVX_JDK_SRC is set but {path} is not there")
+        return path.read_text(encoding="utf-8"), str(path)
+    url = RAW.format(tag=urllib.parse.quote(tag, safe=""), path=HEADER_PATH)
+    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+        return response.read().decode("utf-8"), url
+
+
+def evaluate(expr: str, known: dict[str, int]) -> int:
+    """Work out one constant, given the ones below it.
+
+    The file writes these as `age_shift = self_fwd_shift + self_fwd_bits` and once as
+    a ternary, and wraps one of them in the LP64_ONLY macro. That is the whole
+    language. Anything else raises, because a generator that guesses is worse than
+    no generator: it produces a number that looks generated.
+    """
+    text = expr.strip()
+    text = LP64_ONLY.sub(r"\1", text)
+    text = NOT_LP64.sub("", text)
+    text = text.strip()
+
+    match = TERNARY.match(text)
+    if match:
+        cond = evaluate_arithmetic(match.group("cond"), known, boolean=True)
+        branch = match.group("yes") if cond else match.group("no")
+        return evaluate(branch, known)
+
+    return evaluate_arithmetic(text, known)
+
+
+def evaluate_arithmetic(text: str, known: dict[str, int], boolean: bool = False) -> int:
+    text = text.strip()
+    if not SAFE.match(text):
+        raise ValueError(f"cannot read {text!r}, and guessing is not an option here")
+    scope = dict(ENVIRONMENT)
+    scope.update(known)
+    for name in re.findall(r"[A-Za-z_]\w*", text):
+        if name not in scope:
+            raise ValueError(f"{text!r} uses {name!r}, which is not defined yet")
+    value = eval(text, {"__builtins__": {}}, scope)  # noqa: S307
+    return bool(value) if boolean else int(value)
+
+
+def parse(source: str) -> tuple[dict[str, int], dict[str, int]]:
+    """Return every constant we could work out, and the line each was defined on."""
+    known: dict[str, int] = {}
+    lines: dict[str, int] = {}
+    for number, line in enumerate(source.split("\n"), start=1):
+        match = CONSTANT.match(line)
+        if not match:
+            continue
+        name = match.group("name")
+        if name in known:
+            continue
+        try:
+            known[name] = evaluate(match.group("expr"), known)
+        except ValueError:
+            # Masks and pointer-shaped constants use helpers this does not model.
+            # They are not needed for the layout, so skipping them is honest.
+            continue
+        lines[name] = number
+    return known, lines
+
+
+def layout_comment_lines(source: str) -> dict[str, int]:
+    """Find the two ASCII diagrams at the top of the file, so a lesson can cite them."""
+    found = {}
+    for number, line in enumerate(source.split("\n"), start=1):
+        if "64 bits (with compact headers)" in line:
+            found["compact"] = number
+        elif "64 bits (without compact headers)" in line:
+            found["legacy"] = number
+    return found
+
+
+def build(root: pathlib.Path) -> dict:
+    pin = load_pin(root)
+    tag = pin["jdk_tag"]
+    source, origin = fetch_header(tag)
+    known, lines = parse(source)
+
+    missing = [c for _, s, b, _ in FIELDS for c in (s, b) if c not in known]
+    if missing:
+        raise SystemExit(
+            f"markWord.hpp at {tag} does not define {sorted(set(missing))}. "
+            f"The constants were renamed or restructured upstream, which is a real "
+            f"finding rather than a bug here. Read the file before changing this."
+        )
+
+    fields = []
+    for name, shift_const, bits_const, meaning in FIELDS:
+        shift = known[shift_const]
+        bits = known[bits_const]
+        fields.append(
+            {
+                "name": name,
+                "shift": shift,
+                "bits": bits,
+                "mask": f"0x{((1 << bits) - 1) << shift:016x}",
+                "meaning": meaning,
+                "defined_at": {
+                    "shift": f"{HEADER_PATH}:{lines[shift_const]}@{tag}",
+                    "bits": f"{HEADER_PATH}:{lines[bits_const]}@{tag}",
+                },
+            }
+        )
+
+    total = sum(f["bits"] for f in fields)
+    diagrams = layout_comment_lines(source)
+
+    return {
+        "generated_by": "tools/gen_markword.py",
+        "source": {
+            "path": HEADER_PATH,
+            "tag": tag,
+            "origin": origin if origin.startswith("http") else "local checkout",
+            "sha256": hashlib.sha256(source.encode("utf-8")).hexdigest(),
+            "lines": len(source.split("\n")),
+        },
+        "word_bits": ENVIRONMENT["BitsPerWord"],
+        "fields": fields,
+        "total_field_bits": total,
+        "lock_states": [
+            {"bits": bits, "name": name, "meaning": meaning}
+            for bits, name, meaning in LOCK_STATES
+        ],
+        "diagram_lines": {
+            kind: f"{HEADER_PATH}:{line}@{tag}" for kind, line in diagrams.items()
+        },
+        "note": (
+            "The klass field is present only when UseCompactObjectHeaders is on, which "
+            "is the default on 64 bit platforms from JDK 27. With the flag off, those 22 "
+            "bits are unused in the mark word and the class pointer is a separate 4 byte "
+            "field after it. The C++ oopDesc struct declares that field either way, so "
+            "reading the struct alone will tell you the object has one when it does not."
+        ),
+    }
+
+
+def render(data: dict) -> str:
+    rows = ["bits         field      width  meaning", "-" * 78]
+    for field in reversed(data["fields"]):
+        hi = field["shift"] + field["bits"] - 1
+        span = f"{hi}..{field['shift']}"
+        rows.append(f"{span:<12} {field['name']:<10} {field['bits']:>5}  {field['meaning']}")
+    rows.append("")
+    rows.append(f"{data['total_field_bits']} bits accounted for, in a {data['word_bits']} bit word")
+    rows.append("")
+    rows.append("lock  state      meaning")
+    rows.append("-" * 78)
+    for state in data["lock_states"]:
+        rows.append(f"{state['bits']:<5} {state['name']:<10} {state['meaning']}")
+    rows.append("")
+    rows.append(f"from {data['source']['path']} at {data['source']['tag']}")
+    rows.append(f"sha256 {data['source']['sha256']}")
+    return "\n".join(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if the committed file is stale")
+    parser.add_argument("--print", dest="show", action="store_true", help="print the layout")
+    args = parser.parse_args()
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    data = build(root)
+    text = json.dumps(data, indent=2) + "\n"
+    target = root / OUTPUT
+
+    if args.show:
+        print(render(data))
+        return 0
+
+    if args.check:
+        if not target.is_file():
+            print(f"{OUTPUT} is not committed, run tools/gen_markword.py", file=sys.stderr)
+            return 1
+        committed = target.read_text(encoding="utf-8")
+        if committed != text:
+            old = json.loads(committed)
+            print(f"{OUTPUT} is stale.", file=sys.stderr)
+            if old.get("source", {}).get("sha256") != data["source"]["sha256"]:
+                print(
+                    f"  markWord.hpp changed upstream at {data['source']['tag']}. "
+                    f"This is a driftbot event, not a rebuild: read the diff before "
+                    f"regenerating, because a field that moved breaks every diagram "
+                    f"and every decode in the object layout lessons.",
+                    file=sys.stderr,
+                )
+            else:
+                print("  the file is the same, so the generator changed. Regenerate.", file=sys.stderr)
+            return 1
+        print(f"{OUTPUT} is current at {data['source']['tag']}")
+        return 0
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    print(f"wrote {OUTPUT} from {data['source']['path']} at {data['source']['tag']}")
+    print()
+    print(render(data))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_gen_markword.py
+++ b/tools/test_gen_markword.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Tests for gen_markword.py.
+
+The fixture below is the shape of the real `markWord.hpp` constant chain, cut down to
+what the generator reads. It is a fixture rather than the real file so the tests run
+with no network and so a change upstream shows up in the `--check` job rather than as
+a mysterious unit test failure. Those are different problems and they want different
+error messages.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import gen_markword as gen  # noqa: E402
+
+
+FIXTURE = """\
+// The markWord describes the header of an object.
+//
+//  64 bits (without compact headers):
+//  ----------------------------------
+//  unused:22  hash:31  valhalla:4  age:4  self-fwd:1  lock:2
+//
+//  64 bits (with compact headers):
+//  -------------------------------
+//  klass:22   hash:31  valhalla:4  age:4  self-fwd:1  lock:2
+
+class markWord {
+ public:
+  static const int lock_bits                      = 2;
+  static const int self_fwd_bits                  = 1;
+  static const int age_bits                       = 4;
+  static const int valhalla_reserved_bits         = LP64_ONLY(4) NOT_LP64(0);
+  static const int max_hash_bits                  = BitsPerWord - age_bits - lock_bits - self_fwd_bits - valhalla_reserved_bits;
+  static const int hash_bits                      = max_hash_bits > 31 ? 31 : max_hash_bits;
+
+  static const int lock_shift                     = 0;
+  static const int self_fwd_shift                 = lock_shift + lock_bits;
+  static const int age_shift                      = self_fwd_shift + self_fwd_bits;
+  static const int valhalla_reserved_shift        = age_shift + age_bits;
+  static const int hash_shift                     = valhalla_reserved_shift + valhalla_reserved_bits;
+
+  static const uintptr_t lock_mask_in_place       = right_n_bits(lock_bits) << lock_shift;
+
+  static constexpr int klass_offset_in_bytes      = 4;
+  static constexpr int klass_shift                = hash_shift + hash_bits;
+  static constexpr int klass_bits                 = 22;
+};
+"""
+
+
+class TestEvaluate(unittest.TestCase):
+    def test_a_plain_number(self) -> None:
+        self.assertEqual(gen.evaluate("2", {}), 2)
+
+    def test_a_sum_of_constants_below_it(self) -> None:
+        self.assertEqual(gen.evaluate("a + b", {"a": 3, "b": 4}), 7)
+
+    def test_lp64_only_keeps_the_64_bit_value(self) -> None:
+        self.assertEqual(gen.evaluate("LP64_ONLY(4) NOT_LP64(0)", {}), 4)
+
+    def test_the_ternary_picks_the_right_branch(self) -> None:
+        self.assertEqual(gen.evaluate("m > 31 ? 31 : m", {"m": 53}), 31)
+        self.assertEqual(gen.evaluate("m > 31 ? 31 : m", {"m": 20}), 20)
+
+    def test_an_unknown_name_raises_rather_than_guessing(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            gen.evaluate("right_n_bits(lock_bits)", {"lock_bits": 2})
+        self.assertIn("not defined yet", str(caught.exception))
+
+    def test_something_outside_the_subset_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            gen.evaluate('"a string"', {})
+
+
+class TestParse(unittest.TestCase):
+    def setUp(self) -> None:
+        self.known, self.lines = gen.parse(FIXTURE)
+
+    def test_the_widths_come_out(self) -> None:
+        self.assertEqual(self.known["lock_bits"], 2)
+        self.assertEqual(self.known["self_fwd_bits"], 1)
+        self.assertEqual(self.known["age_bits"], 4)
+        self.assertEqual(self.known["valhalla_reserved_bits"], 4)
+        self.assertEqual(self.known["klass_bits"], 22)
+
+    def test_the_hash_width_is_capped_at_31(self) -> None:
+        self.assertEqual(self.known["max_hash_bits"], 53)
+        self.assertEqual(self.known["hash_bits"], 31)
+
+    def test_the_shifts_chain_correctly(self) -> None:
+        self.assertEqual(self.known["lock_shift"], 0)
+        self.assertEqual(self.known["self_fwd_shift"], 2)
+        self.assertEqual(self.known["age_shift"], 3)
+        self.assertEqual(self.known["valhalla_reserved_shift"], 7)
+        self.assertEqual(self.known["hash_shift"], 11)
+        self.assertEqual(self.known["klass_shift"], 42)
+
+    def test_a_constant_it_cannot_read_is_skipped_not_guessed(self) -> None:
+        self.assertNotIn("lock_mask_in_place", self.known)
+
+    def test_every_constant_records_the_line_it_came_from(self) -> None:
+        self.assertEqual(FIXTURE.split("\n")[self.lines["klass_shift"] - 1].strip(),
+                         "static constexpr int klass_shift                = hash_shift + hash_bits;")
+
+    def test_the_fields_fill_the_word_exactly(self) -> None:
+        total = sum(
+            self.known[bits] for _, _, bits, _ in gen.FIELDS
+        )
+        self.assertEqual(total, 64)
+
+    def test_no_two_fields_overlap(self) -> None:
+        spans = []
+        for _, shift_const, bits_const, _ in gen.FIELDS:
+            shift = self.known[shift_const]
+            spans.append((shift, shift + self.known[bits_const]))
+        spans.sort()
+        for (_, end), (start, _) in zip(spans, spans[1:]):
+            self.assertEqual(end, start)
+
+    def test_both_diagrams_are_found(self) -> None:
+        found = gen.layout_comment_lines(FIXTURE)
+        self.assertEqual(set(found), {"compact", "legacy"})
+        self.assertLess(found["legacy"], found["compact"])
+
+
+class TestCommittedOutput(unittest.TestCase):
+    """The committed file has to say what the generator says, and be internally sane.
+
+    This does not fetch anything. It reads what is on disk, which is what a lesson
+    and a diagram actually consume, and checks the properties that would make one of
+    them silently wrong.
+    """
+
+    def setUp(self) -> None:
+        import json
+
+        root = pathlib.Path(__file__).resolve().parent.parent
+        path = root / gen.OUTPUT
+        if not path.is_file():
+            self.skipTest(f"{gen.OUTPUT} is not generated yet")
+        self.data = json.loads(path.read_text(encoding="utf-8"))
+
+    def test_the_fields_fill_the_word(self) -> None:
+        self.assertEqual(self.data["total_field_bits"], self.data["word_bits"])
+
+    def test_every_mask_matches_its_shift_and_width(self) -> None:
+        for field in self.data["fields"]:
+            expected = ((1 << field["bits"]) - 1) << field["shift"]
+            self.assertEqual(int(field["mask"], 16), expected, field["name"])
+
+    def test_every_field_cites_the_line_it_came_from(self) -> None:
+        for field in self.data["fields"]:
+            for kind in ("shift", "bits"):
+                citation = field["defined_at"][kind]
+                self.assertIn("markWord.hpp:", citation)
+                self.assertIn("@", citation)
+
+    def test_the_recorded_hash_is_a_sha256(self) -> None:
+        self.assertRegex(self.data["source"]["sha256"], r"^[0-9a-f]{64}$")
+
+    def test_the_observed_mark_word_decodes_to_the_observed_identity_hash(self) -> None:
+        """The one test that is not about the generator.
+
+        These two 64 bit values were read out of a live JDK 27 on aarch64, before and
+        after calling System.identityHashCode on the same object, which returned
+        0x1dfe2924. If applying the generated shifts to the second value does not
+        produce that number, then the layout this repository publishes is wrong in a
+        way that no amount of parsing correctness would catch.
+        """
+        before = 0x0017AC0000000011
+        after = 0x0017ACEFF1492011
+        observed_hash = 0x1DFE2924
+
+        by_name = {f["name"]: f for f in self.data["fields"]}
+
+        def extract(word: int, name: str) -> int:
+            field = by_name[name]
+            return (word >> field["shift"]) & ((1 << field["bits"]) - 1)
+
+        self.assertEqual(extract(before, "hash"), 0)
+        self.assertEqual(extract(after, "hash"), observed_hash)
+        self.assertEqual(extract(before, "klass"), extract(after, "klass"))
+        self.assertEqual(extract(after, "lock"), 0b01)
+        self.assertEqual(extract(after, "self_fwd"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The mark word is the first thing lesson O01 has to draw, and its bit positions are the first numbers this project would have been tempted to type by hand.

They are not in the JVMS. Section 2.7 says, in full, that the JVM does not mandate any particular internal structure for objects, so there is nothing normative to cite. They are not in any current book either. They live in `src/hotspot/share/oops/markWord.hpp` as a chain of constants where each one is defined in terms of the one below it, and those positions moved twice in the last three releases. A number typed into a diagram is a number that is wrong after the next release and that nobody notices, and this repository is supposed to be the one that notices.

## What this adds

`tools/gen_markword.py` reads `markWord.hpp` at the pinned tag and works the chain out. It models the small subset of C++ those constants are written in: the `LP64_ONLY` and `NOT_LP64` macros, one ternary, and arithmetic over names that are already resolved. Anything outside that subset raises instead of guessing. That is deliberate. A generator that guesses is worse than no generator, because it produces a number that looks generated.

The source comes from `raw.githubusercontent.com` at the tag in `docs/pin.json`, or from a local OpenJDK checkout when `JVX_JDK_SRC` points at one, which is what makes it work in a build tree and offline.

The output is `docs/generated/markword.json`, committed, with every field's shift, width, mask, and the `markWord.hpp` line each of those came from:

```
bits         field      width  meaning
------------------------------------------------------------------------------
63..42       klass         22  the compressed class pointer, present only when UseCompactObjectHeaders is on
41..11       hash          31  the identity hash, written the first time anything asks for it
10..7        valhalla       4  reserved for Valhalla, unused today
6..3         age            4  how many collections the object has survived
2..2         self_fwd       1  set when a collector forwarded the object in place
1..0         lock           2  the lock state, and whether a collector has marked or forwarded the object

64 bits accounted for, in a 64 bit word
```

The line numbers are what make a citation in a lesson resolvable. The sha256 of the whole file is what turns "the file has not changed underneath us" from an assumption into something a job can check.

## The test that actually matters

Eighteen of the nineteen tests are about parsing, and they are the easy ones. The nineteenth takes two mark words read out of a live JDK 27 on this laptop, one before and one after calling `System.identityHashCode` on the same object:

```
before  0x0017ac0000000011
after   0x0017acEff1492011
identityHashCode returned 0x1dfe2924
```

It applies the generated shifts to the second value and checks that the hash field comes out as `0x1dfe2924`, that the klass field is unchanged between the two, that the lock bits are `01`, and that `self_fwd` is clear. Parsing correctness alone would not catch a layout that is right about the file and wrong about the machine. This test would.

## The trap this avoids

The generated file carries a note about a mistake that is easy to make and hard to see. The `klass` field is only really there when `UseCompactObjectHeaders` is on, which is the default on 64 bit from JDK 27. With the flag off, those 22 bits are unused and the class pointer is a separate 4 byte field after the mark word. The C++ `oopDesc` struct declares that field either way, so a generator that reads the struct and stops will describe an object that does not exist in the default configuration.

That is not hypothetical. Reading the Serviceability Agent type database on server3 with `jhsdb clhsdb` reports `_compressed_klass` at offset 8 in `oopDesc` under compact headers, where the field is unused. The SA is the better source in general because it is what the VM itself believes, but on this particular question it needs cross referencing against `UseCompactObjectHeaders` or it produces a Blueprint section that is false by default. Noted here so the SA half of `bpc` does not walk into it.

## CI

New `generated` job, six minute budget, running the unit tests and then `gen_markword.py --check`.

It is a separate job from `notebooks` on purpose. It is the only thing in CI that reaches out to `openjdk/jdk`, so when GitHub's raw host has a bad minute the failure says the generated file check could not reach upstream, rather than quietly discrediting the determinism check next door.

`--check` distinguishes two failures that want different responses. If the recorded sha256 no longer matches, `markWord.hpp` changed upstream, which is a drift event: read the diff first, because a field that moved breaks every diagram and every decode in the object layout lessons. If the file is identical and the output differs, the generator changed and the answer is simply to regenerate.

## What this does not do

It does not close #3. That probe asks whether `bpc` can read struct layouts out of the SA type database, and this is the other half, the one that reads headers. Both are needed and the interesting cases are where they disagree. This is the half that works with no process to attach to, which is why it is first.

Groundwork for #12.
