### PR TITLE
jvx v0.1: the helper surface every lesson gets, inlined into a generated cell

### DIFF
--- a/docs/lesson-format.md
+++ b/docs/lesson-format.md
@@ -58,10 +58,31 @@ jvx.run("-XX:+UseCompactObjectHeaders", () -> ClassLayout.parseClass(Object.clas
 | `tags=[...]` | Any of `predict`, `bake`, `slow`, `solution`, `skip-ci` |
 | `env=` | `E0`, `E1` or `E2`. Defaults to `E0` |
 | `replay=` | The recorded transcript a tier 0 reader steps through instead of running an `E1` cell |
+| `generated=` | `badge` or `bootstrap`. The build writes the cell's body, the lesson only says where it goes |
 
 Anything else on the marker line is an error rather than something ignored, because a silently ignored directive is a lesson that does not do what its author thinks it does.
 
 Give an `id=` to any cell a claim depends on, and then never change it. The claim ledger cites cells by id, so renaming one breaks the ledger entry without breaking the build. Ids are additive. Name them for what they show, so `header_size_compact` rather than `cell_7`.
+
+## Generated cells
+
+Two cells in every lesson are written by the build rather than by the author. The lesson source declares where they go and leaves them empty:
+
+```python
+# %% [markdown] id=badge generated=badge
+
+# %% id=bootstrap generated=bootstrap env=E0
+```
+
+Writing anything in the body of a generated cell is an error, not a warning. The build would overwrite it, and losing somebody's work silently is worse than refusing it loudly.
+
+`badge` is the Open in Colab badge, the lesson's question and a line saying which pin the numbers on the page came from.
+
+`bootstrap` is the cell every reader runs first. It inlines every file in `jvx/` in filename order, then calls `jvx.banner()`. The mark word bit positions inside it are filled in from `docs/generated/markword.json`, which `tools/gen_markword.py` reads out of HotSpot's own `markWord.hpp` at the pinned tag, so no bit position is typed by hand anywhere between the header file and the reader's screen.
+
+Inlining rather than fetching a jar is the right shape for now for one reason: a reader who clicks a badge should not be waiting on Maven Central, and a project with no release yet should not pretend it has one. When `jvx` is published this cell becomes a `%maven` line and nothing else changes, because every lesson already goes through `jvx.` rather than through the classes underneath.
+
+A generated cell's id is a hash of what ships, not of the empty placeholder in the source. So editing anything in `jvx/` moves the bootstrap cell's id in every lesson at once, which is the honest answer: the cell really did change in every one of them.
 
 ## Tags
 
@@ -95,7 +116,9 @@ Beyond the byte comparison, `build.py check` enforces the caps and the structura
 
 A lesson with `status: draft` in its front matter is exempt from the prediction gate rule and the grader rule, which is what lets a work in progress live on a branch without turning CI red for a week.
 
-`tools/prosecheck.py` reads the markdown cells out of `lesson.py` and applies the prose rules to them, reported against their real line numbers in that file.
+It also checks the generated cells: exactly one `generated=badge` and one `generated=bootstrap` per lesson, an empty body on both, and the bootstrap being the first code cell. That last one matters because the bootstrap is what defines `jvx`, so a code cell above it runs against a kernel that does not have it yet, and that failure reads as "the lesson is broken" to a reader who has done nothing wrong.
+
+`tools/prosecheck.py` reads the markdown cells out of `lesson.py` and the comments out of `jvx/*.jsh`, and applies the prose rules to them, reported against their real line numbers in the file they came from. The jvx comments are checked because they are inlined verbatim into the bootstrap cell, so they are the first thing a reader sees. The wrap rule is the one exception there: hard wrapping a code comment is what every reader expects, and the rule exists to keep prose diffs readable rather than to forbid wrapping as such.
 
 ## Running the tests
 
@@ -103,4 +126,6 @@ A lesson with `status: draft` in its front matter is exempt from the prediction 
 python tools/test_build.py
 ```
 
-Thirty one tests, standard library only. The two that matter most are `test_three_builds_are_byte_identical` and `test_check_catches_a_one_character_edit`, because those two are the promise the pipeline rests on.
+Forty one tests, standard library only. The two that matter most are `test_three_builds_are_byte_identical` and `test_check_catches_a_one_character_edit`, because those two are the promise the pipeline rests on.
+
+The harness copies the real `jvx/` and the real `docs/generated/markword.json` into its temporary directory rather than using a fixture, so the generated cell tests build against the sources that actually ship.

--- a/jvx/00-imports.jsh
+++ b/jvx/00-imports.jsh
@@ -1,0 +1,9 @@
+// JShell imports a useful default set, but not these. They are separate snippets on
+// purpose: an import in JShell applies to everything typed afterwards, so putting
+// them first means a reader's own cells get them too without asking.
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.VMOption;

--- a/jvx/10-markword.jsh
+++ b/jvx/10-markword.jsh
@@ -1,0 +1,119 @@
+// The mark word is the first eight bytes of every object on the heap, and it carries
+// several unrelated things at once: the lock state, the identity hash, the age the
+// collector uses to decide about promotion, and on JDK 27 the class pointer as well.
+//
+// None of the numbers below are typed by hand. The placeholder line further down is
+// replaced by tools/build.py using docs/generated/markword.json, which
+// tools/gen_markword.py works out from HotSpot's own markWord.hpp at the pinned tag.
+// The citation on each field is the line of markWord.hpp it came from, so a reader
+// who does not believe a number can go and look at the line that produced it.
+
+class MarkWord {
+
+    static final class Field {
+        final String name;
+        final int shift;
+        final int bits;
+        final String meaning;
+        final String citation;
+
+        Field(String name, int shift, int bits, String meaning, String citation) {
+            this.name = name;
+            this.shift = shift;
+            this.bits = bits;
+            this.meaning = meaning;
+            this.citation = citation;
+        }
+
+        /** The value of this field in the given word. */
+        long of(long word) {
+            return (word >>> shift) & ((1L << bits) - 1);
+        }
+
+        /** The bit positions this field occupies, high end first, the way a diagram reads. */
+        String span() {
+            return (shift + bits - 1) + ".." + shift;
+        }
+    }
+
+    // @jvx:markword_fields@
+
+    static Field field(String name) {
+        for (Field f : FIELDS) {
+            if (f.name.equals(name)) return f;
+        }
+        throw new IllegalArgumentException(
+            "no field called " + name + " in the mark word at " + SOURCE_TAG);
+    }
+
+    static long get(long word, String name) {
+        return field(name).of(word);
+    }
+
+    static String hex(long word) {
+        return String.format("0x%016x", word);
+    }
+
+    /** All 64 bits, grouped in bytes, so the reader can count them. */
+    static String bin(long word) {
+        StringBuilder b = new StringBuilder(72);
+        for (int i = 63; i >= 0; i--) {
+            b.append((word >>> i) & 1L);
+            if (i % 8 == 0 && i != 0) b.append(' ');
+        }
+        return b.toString();
+    }
+
+    /**
+     * The same 64 bits with each field's own bits shown and everything else dimmed to
+     * a dot. Reading a hex number and believing where the boundaries are is exactly
+     * the step where people go wrong, so this draws the boundaries.
+     */
+    static String ruler(long word) {
+        StringBuilder out = new StringBuilder();
+        for (int i = FIELDS.length - 1; i >= 0; i--) {
+            Field f = FIELDS[i];
+            StringBuilder row = new StringBuilder(72);
+            for (int bit = 63; bit >= 0; bit--) {
+                boolean mine = bit >= f.shift && bit < f.shift + f.bits;
+                row.append(mine ? Character.forDigit((int) ((word >>> bit) & 1L), 10) : '.');
+                if (bit % 8 == 0 && bit != 0) row.append(' ');
+            }
+            out.append(row).append("  ").append(f.name).append('\n');
+        }
+        return out.toString();
+    }
+
+    static String decode(long word) {
+        StringBuilder b = new StringBuilder();
+        b.append(hex(word)).append('\n');
+        b.append(bin(word)).append('\n');
+        b.append('\n');
+        b.append(ruler(word));
+        b.append('\n');
+        b.append(String.format("%-8s %-9s %-12s %s%n", "bits", "field", "value", "meaning"));
+        b.append("-".repeat(78)).append('\n');
+        for (int i = FIELDS.length - 1; i >= 0; i--) {
+            Field f = FIELDS[i];
+            b.append(String.format("%-8s %-9s %-12s %s%n",
+                f.span(), f.name, "0x" + Long.toHexString(f.of(word)), f.meaning));
+        }
+        b.append('\n');
+        int lock = (int) get(word, "lock");
+        b.append("lock ").append(LOCK_BITS[lock]).append(", ").append(LOCK_MEANING[lock]).append('\n');
+        return b.toString();
+    }
+
+    /** Where every number above came from, for a reader who wants to check one. */
+    static String provenance() {
+        StringBuilder b = new StringBuilder();
+        b.append("generated from ").append(SOURCE_PATH).append(" at ").append(SOURCE_TAG).append('\n');
+        b.append("sha256 ").append(SOURCE_SHA256).append('\n');
+        b.append('\n');
+        for (int i = FIELDS.length - 1; i >= 0; i--) {
+            Field f = FIELDS[i];
+            b.append(String.format("%-9s %s%n", f.name, f.citation));
+        }
+        return b.toString();
+    }
+}

--- a/jvx/20-jvx.jsh
+++ b/jvx/20-jvx.jsh
@@ -1,0 +1,197 @@
+// jvx is the small helper surface every lesson gets for free. It is deliberately thin.
+// Anything it does that a reader could do themselves in three lines, it does in a way
+// they can read, and it never hides the tool underneath it. When a lesson wants JOL or
+// jcmd or jfr, the lesson calls JOL or jcmd or jfr, because watching the real tool is
+// the point and a wrapper would be one more thing to trust.
+//
+// The class name is lower case. That is not a mistake and not Java style. It is a
+// namespace that reads like one at a call site, `jvx.mark(o)`, and every lesson has it.
+
+class jvx {
+
+    static final String PIN = "@jvx:pin@";
+    static final String BUILT_FROM = "@jvx:sources@";
+
+    // -- reading raw object memory ------------------------------------------------
+    //
+    // There is no supported API for reading the bytes of an object header. That is not
+    // an oversight, it is the whole reason the mark word is an implementation detail:
+    // the JVMS does not mandate any internal structure for objects at all (JVMS 2.7),
+    // so there is nothing for an API to promise. Two internal doors are open on JDK 27
+    // and jvx tries them in this order.
+    //
+    //   1. jdk.internal.misc.Unsafe, which needs
+    //      --add-exports java.base/jdk.internal.misc=ALL-UNNAMED on the command line.
+    //      Preferred, because it prints nothing.
+    //   2. sun.misc.Unsafe, which needs no flags and prints four lines of terminal
+    //      deprecation warning the first time. It still works on JDK 27 and it is on
+    //      its way out.
+    //
+    // Which door opened is not hidden. jvx.markRoute() says, and the banner prints it,
+    // because "where did this number come from" is a question a reader is entitled to
+    // ask about a number that came from reading memory directly.
+
+    private static Object unsafe;
+    private static Method getLongMethod;
+    private static String markRoute = "not tried yet";
+
+    private static void openUnsafe() {
+        if (getLongMethod != null) return;
+        try {
+            Class<?> c = Class.forName("jdk.internal.misc.Unsafe");
+            unsafe = c.getMethod("getUnsafe").invoke(null);
+            getLongMethod = c.getMethod("getLong", Object.class, long.class);
+            markRoute = "jdk.internal.misc.Unsafe";
+            return;
+        } catch (Throwable ignored) {
+            // Not exported to us. Fall through to the older door.
+        }
+        try {
+            Class<?> c = Class.forName("sun.misc.Unsafe");
+            Field f = c.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            unsafe = f.get(null);
+            getLongMethod = c.getMethod("getLong", Object.class, long.class);
+            markRoute = "sun.misc.Unsafe (deprecated for removal, expect a warning)";
+            return;
+        } catch (Throwable t) {
+            markRoute = "neither door opened: " + t;
+            throw new UnsupportedOperationException(
+                "cannot read object memory on this JVM. Start the kernel with "
+                + "--add-exports java.base/jdk.internal.misc=ALL-UNNAMED. " + markRoute);
+        }
+    }
+
+    static String markRoute() {
+        openUnsafe();
+        return markRoute;
+    }
+
+    /** The eight bytes at offset 0 of an object, exactly as they sit in memory. */
+    static long mark(Object o) {
+        openUnsafe();
+        try {
+            return (Long) getLongMethod.invoke(unsafe, o, 0L);
+        } catch (Exception e) {
+            throw new RuntimeException("reading the mark word failed", e);
+        }
+    }
+
+    /** The mark word, printed with its fields separated out. */
+    static void header(Object o) {
+        System.out.print(MarkWord.decode(mark(o)));
+    }
+
+    static String hex(long word) {
+        return MarkWord.hex(word);
+    }
+
+    static long field(Object o, String name) {
+        return MarkWord.get(mark(o), name);
+    }
+
+    /**
+     * The mark word of an object nothing has ever touched.
+     *
+     * This exists because of a trap that is very easy to fall into and impossible to
+     * see. JShell echoes the value of any expression you do not end with a semicolon,
+     * and echoing an object calls toString(), and Object.toString() calls hashCode(),
+     * and calling hashCode() on an object is what makes HotSpot write an identity hash
+     * into its mark word. So this:
+     *
+     *     Object o = new Object()
+     *
+     * hands you an object whose hash field is already filled in, and the "before"
+     * measurement you were about to take is gone. The same line with a semicolon on
+     * the end does not, because JShell prints nothing.
+     *
+     * Nothing here can touch the object between allocating it and reading it, because
+     * the reference never leaves this method. It is the honest "before".
+     */
+    static long freshMark() {
+        return mark(new Object());
+    }
+
+    /** Where every bit position jvx believes in came from. */
+    static void provenance() {
+        System.out.print(MarkWord.provenance());
+    }
+
+    // -- asking the VM about itself -----------------------------------------------
+    //
+    // This part needs no internal access at all. HotSpotDiagnosticMXBean is supported
+    // API in the jdk.management module and it answers for any flag the VM has,
+    // including the origin, which is the part people forget to check. A flag that is
+    // true because it is the default and a flag that is true because somebody put it
+    // on the command line are different facts, and a lesson that confuses them is
+    // teaching a local accident as a general truth.
+
+    private static HotSpotDiagnosticMXBean diagnostic() {
+        return ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+    }
+
+    /** A flag's value, or null when this VM has no such flag. */
+    static String flag(String name) {
+        try {
+            return diagnostic().getVMOption(name).getValue();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /** Where a flag's value came from: default, command line, ergonomic, and so on. */
+    static String flagOrigin(String name) {
+        try {
+            return diagnostic().getVMOption(name).getOrigin().toString();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    static boolean on(String name) {
+        return "true".equals(flag(name));
+    }
+
+    /** A flag with its origin, the way `java -XX:+PrintFlagsFinal` would show it. */
+    static void flags(String... names) {
+        for (String name : names) {
+            String value = flag(name);
+            if (value == null) {
+                System.out.printf("%-28s %-10s %s%n", name, "-", "this VM has no such flag");
+            } else {
+                System.out.printf("%-28s %-10s {%s}%n", name, value, flagOrigin(name).toLowerCase());
+            }
+        }
+    }
+
+    // -- what am I running on -----------------------------------------------------
+
+    /**
+     * Printed by the bootstrap cell of every lesson. It is not decoration. Almost every
+     * observation in this project is true of one configuration and false of another, so
+     * a reader comparing their output with the page needs to see, on the same screen,
+     * which configuration produced theirs.
+     */
+    static void banner() {
+        Runtime.Version v = Runtime.version();
+        System.out.printf("java      %s  (%s)%n", v, System.getProperty("java.vm.version"));
+        System.out.printf("vm        %s%n", System.getProperty("java.vm.name"));
+        System.out.printf("on        %s %s%n",
+            System.getProperty("os.name"), System.getProperty("os.arch"));
+        System.out.printf("lessons pinned to %s%n", PIN);
+        System.out.println();
+        // Three flags, not four. UseCompressedClassPointers used to belong in this
+        // list and no longer exists on JDK 27, which is exactly why flag() returns
+        // null for a missing flag rather than throwing: a banner that dies because
+        // the VM moved on is a banner that stops anyone from reading anything.
+        flags("UseCompactObjectHeaders", "UseCompressedOops", "ObjectAlignmentInBytes");
+        System.out.println();
+        System.out.println("mark word read through " + markRoute());
+        if (!v.toString().startsWith(PIN.replace("jdk-", "").split("\\+")[0])) {
+            System.out.println();
+            System.out.println("NOTE: this VM is not the pinned one. Numbers below may differ from the page,");
+            System.out.println("      and where they do, this VM is right about this VM and the page is right");
+            System.out.println("      about " + PIN + ".");
+        }
+    }
+}

--- a/lychee.toml
+++ b/lychee.toml
@@ -11,6 +11,12 @@ exclude = [
   # The advisory form 404s for anyone without write access, including the
   # checker, so a working link and a broken one look the same from here.
   "^https://github\\.com/tamnd/jvm-internals/security/advisories/new",
+  # A Colab badge points at the notebook's path on main, which on the pull
+  # request that adds the lesson does not exist yet. The link is correct and
+  # unresolvable at the same time, and it becomes resolvable on merge. That the
+  # path is right is checked in tools/test_build.py instead, which can check it
+  # without asking Google.
+  "^https://colab\\.research\\.google\\.com",
 ]
 
 max_retries = 3

--- a/tools/build.py
+++ b/tools/build.py
@@ -63,7 +63,18 @@ CELL_TYPES = {"code", "markdown", "raw"}
 # Directives a cell may carry. Anything else is a typo and is rejected rather than
 # ignored, because a silently ignored directive is a lesson that does not do what
 # its author thinks it does.
-KNOWN_DIRECTIVES = {"id", "tags", "env", "replay"}
+KNOWN_DIRECTIVES = {"id", "tags", "env", "replay", "generated"}
+
+# A cell whose body build.py writes. The lesson source declares where it goes and
+# leaves it empty, so the badge and the helper surface cannot drift lesson by lesson
+# and nobody has to remember to update 112 copies of the same block.
+KNOWN_GENERATED = {"badge", "bootstrap"}
+
+# Where the notebooks are read from when a badge is clicked. Colab fetches from a
+# GitHub path rather than from the repository it happens to have been opened from,
+# so this is the one place in the build that knows the repository's name.
+REPO = "tamnd/jvm-internals"
+DEFAULT_BRANCH = "main"
 
 KNOWN_TAGS = {"predict", "bake", "slow", "solution", "skip-ci"}
 
@@ -203,8 +214,13 @@ class Cell:
     def env(self) -> str:
         return self.directives.get("env", "E0")
 
-    def digest(self, salt: int = 0) -> str:
+    def digest(self, salt: int = 0, text: str | None = None) -> str:
         """A content hash over everything that decides what the cell renders as.
+
+        `text` is the source as it ends up in the notebook, which is the same thing as
+        `self.source` for an ordinary cell and the filled in version for a generated
+        one. Hashing what ships rather than what was written is what makes a change to
+        jvx show up as a changed bootstrap cell instead of an invisible one.
 
         The salt only ever moves off zero when two cells in one lesson are byte for
         byte identical, which nbformat forbids because cell ids must be unique.
@@ -212,7 +228,7 @@ class Cell:
         parts = [
             self.cell_type,
             json.dumps(self.directives, sort_keys=True, separators=(",", ":")),
-            self.source,
+            self.source if text is None else text,
         ]
         if salt:
             parts.append(f"#{salt}")
@@ -268,6 +284,11 @@ def parse_directives(rest: str, path: pathlib.Path, lineno: int) -> tuple[str, d
             f"{path}:{lineno}: a cell id is lower case letters, digits and underscores, "
             f"got {directives['id']!r}"
         )
+    if "generated" in directives and directives["generated"] not in KNOWN_GENERATED:
+        raise LessonError(
+            f"{path}:{lineno}: generated is one of {sorted(KNOWN_GENERATED)}, "
+            f"got {directives['generated']!r}"
+        )
 
     return cell_type, directives
 
@@ -301,7 +322,9 @@ def parse_cells(lines: list[str], start: int, path: pathlib.Path) -> list[Cell]:
             pending.append(raw)
 
     flush()
-    return [c for c in cells if c.source.strip()]
+    # An empty cell is a stray marker and gets dropped, except for a generated one,
+    # where empty is the correct and required state: build.py fills it in.
+    return [c for c in cells if c.source.strip() or c.directives.get("generated")]
 
 
 def strip_comment_prefix(source: str) -> str:
@@ -381,6 +404,168 @@ def load_all(root: pathlib.Path) -> list[Lesson]:
 
 
 # ---------------------------------------------------------------------------
+# Generated cells
+# ---------------------------------------------------------------------------
+
+
+def java_string(text: str) -> str:
+    """Quote a string for Java source.
+
+    JSON string escaping and Java string escaping agree on everything that can appear
+    here, so this borrows the standard library's rather than hand rolling a second one.
+    """
+    return json.dumps(text, ensure_ascii=True)
+
+
+def markword_java(root: pathlib.Path) -> str:
+    """The mark word field table, as Java, from what gen_markword.py read out of HotSpot.
+
+    This is the join between the two halves. `gen_markword.py` reads `markWord.hpp` at
+    the pinned tag and writes JSON; this turns that JSON into the constants a reader's
+    cell actually calls. Nobody types a bit position anywhere along the way.
+    """
+    path = root / "docs" / "generated" / "markword.json"
+    if not path.is_file():
+        raise LessonError(
+            f"{path} is not there. Run `python tools/gen_markword.py` first: the "
+            f"bootstrap cell needs the bit positions and this build will not invent them."
+        )
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    lines = [
+        f'static final String SOURCE_PATH = {java_string(data["source"]["path"])};',
+        f'static final String SOURCE_TAG = {java_string(data["source"]["tag"])};',
+        f'static final String SOURCE_SHA256 = {java_string(data["source"]["sha256"])};',
+        "",
+        "static final Field[] FIELDS = {",
+    ]
+    for field in data["fields"]:
+        lines.append(
+            "    new Field({name}, {shift}, {bits},".format(
+                name=java_string(field["name"]), shift=field["shift"], bits=field["bits"]
+            )
+        )
+        lines.append(f'        {java_string(field["meaning"])},')
+        lines.append(f'        {java_string(field["defined_at"]["shift"])}),')
+    lines.append("};")
+    lines.append("")
+    lines.append(
+        "static final String[] LOCK_BITS = {"
+        + ", ".join(java_string(s["bits"]) for s in data["lock_states"])
+        + "};"
+    )
+    lines.append("static final String[] LOCK_MEANING = {")
+    for state in data["lock_states"]:
+        lines.append(f'    {java_string(state["name"] + ", " + state["meaning"])},')
+    lines.append("};")
+
+    return "\n".join("    " + line if line else "" for line in lines)
+
+
+class Context:
+    """Everything the build needs that is not the lesson itself.
+
+    Read once per run rather than once per lesson, because 112 lessons reading the
+    same three files is 336 reads to produce identical bytes, and because reading them
+    once is also what guarantees every lesson gets the same helper surface.
+    """
+
+    def __init__(self, root: pathlib.Path):
+        self.root = root
+        self.pin = load_pin(root)
+        self._bootstrap: str | None = None
+
+    @property
+    def jdk_tag(self) -> str:
+        return str(self.pin.get("jdk_tag", "unpinned"))
+
+    def jvx_sources(self) -> list[pathlib.Path]:
+        jvx = self.root / "jvx"
+        if not jvx.is_dir():
+            raise LessonError("jvx/ is not there, and the bootstrap cell is built from it")
+        found = sorted(jvx.glob("*.jsh"))
+        if not found:
+            raise LessonError("jvx/ has no .jsh files, so there is no helper surface to inline")
+        return found
+
+    def bootstrap(self) -> str:
+        """The one cell every lesson runs first.
+
+        It inlines `jvx/*.jsh` rather than fetching a jar. That is the right shape for
+        now for one reason: a reader in Colab clicking a badge should not be waiting on
+        Maven Central, and a project with no release yet should not be pretending it
+        has one. When jvx is published this cell becomes a `%maven` line and nothing
+        else in the build changes, because everything above it already goes through
+        `jvx.` rather than through the classes underneath.
+        """
+        if self._bootstrap is not None:
+            return self._bootstrap
+
+        sources = self.jvx_sources()
+        names = ", ".join(f"jvx/{p.name}" for p in sources)
+
+        header = [
+            "// Generated by tools/build.py. Do not edit this cell, it is overwritten on",
+            "// every build. Edit the sources and run `python tools/build.py notebooks`.",
+            "//",
+            f"// helper surface   {names}",
+            "// bit positions    docs/generated/markword.json, read by tools/gen_markword.py",
+            f"//                  from src/hotspot/share/oops/markWord.hpp at {self.jdk_tag}",
+            "//",
+            "// This cell assumes a Java kernel is already running. Installing the pinned",
+            "// JDK from a cold Colab runtime is a separate step that is still being",
+            "// measured, and it goes here when it is. See issue #1.",
+        ]
+
+        blocks = ["\n".join(header)]
+        for path in sources:
+            body = path.read_text(encoding="utf-8").strip("\n")
+            body = body.replace("@jvx:pin@", self.jdk_tag)
+            body = body.replace("@jvx:sources@", names)
+            if "@jvx:markword_fields@" in body:
+                generated = markword_java(self.root)
+                body = "\n".join(
+                    generated if line.strip() == "// @jvx:markword_fields@" else line
+                    for line in body.split("\n")
+                )
+            leftover = re.search(r"@jvx:\w+@", body)
+            if leftover:
+                raise LessonError(
+                    f"{path}: nothing filled in {leftover.group(0)}, so the bootstrap "
+                    f"would ship a placeholder to a reader"
+                )
+            blocks.append(body)
+
+        blocks.append("jvx.banner()")
+        self._bootstrap = "\n\n".join(blocks)
+        return self._bootstrap
+
+    def badge(self, lesson: Lesson) -> str:
+        url = (
+            f"https://colab.research.google.com/github/{REPO}/blob/"
+            f"{DEFAULT_BRANCH}/notebooks/{lesson.id}/lesson.ipynb"
+        )
+        return "\n".join(
+            [
+                f"[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)]({url})",
+                "",
+                f"**{lesson.front['question']}**",
+                "",
+                f"Run the cell below first. Everything after it assumes `jvx` is loaded, and "
+                f"the numbers on this page came from `{self.jdk_tag}`.",
+            ]
+        )
+
+    def generate(self, lesson: Lesson, cell: Cell) -> str:
+        kind = cell.directives["generated"]
+        if kind == "bootstrap":
+            return self.bootstrap()
+        if kind == "badge":
+            return self.badge(lesson)
+        raise LessonError(f"{lesson.path}: no generator for {kind!r}")
+
+
+# ---------------------------------------------------------------------------
 # Notebook generation
 # ---------------------------------------------------------------------------
 
@@ -416,7 +601,7 @@ def load_baked(lesson: Lesson, cell: Cell) -> list:
     return recorded
 
 
-def cell_to_json(lesson: Lesson, cell: Cell, cell_id: str) -> dict:
+def cell_to_json(lesson: Lesson, cell: Cell, cell_id: str, source_text: str) -> dict:
     metadata: dict = {}
     if cell.name:
         metadata["jvx_id"] = cell.name
@@ -424,10 +609,12 @@ def cell_to_json(lesson: Lesson, cell: Cell, cell_id: str) -> dict:
         metadata["jvx_env"] = cell.env
     if cell.directives.get("replay"):
         metadata["jvx_replay"] = cell.directives["replay"]
+    if cell.directives.get("generated"):
+        metadata["jvx_generated"] = cell.directives["generated"]
     if cell.tags:
         metadata["tags"] = cell.tags
 
-    source = cell.source.split("\n")
+    source = source_text.split("\n")
     source = [line + "\n" for line in source[:-1]] + [source[-1]]
 
     out: dict = {
@@ -444,17 +631,21 @@ def cell_to_json(lesson: Lesson, cell: Cell, cell_id: str) -> dict:
     return out
 
 
-def build_notebook(lesson: Lesson) -> str:
+def build_notebook(lesson: Lesson, ctx: Context) -> str:
     seen: dict[str, int] = {}
     cells = []
     for cell in lesson.cells:
+        text = ctx.generate(lesson, cell) if cell.directives.get("generated") else cell.source
+        # The id hashes the built source, not the source file's placeholder, so a
+        # change to jvx moves the bootstrap cell's id in every lesson at once. That
+        # is the honest answer: the cell really did change in every one of them.
         salt = 0
-        digest = cell.digest()
+        digest = cell.digest(text=text)
         while digest in seen:
             salt += 1
-            digest = cell.digest(salt)
+            digest = cell.digest(salt, text=text)
         seen[digest] = 1
-        cells.append(cell_to_json(lesson, cell, digest))
+        cells.append(cell_to_json(lesson, cell, digest, text))
 
     notebook = {
         "cells": cells,
@@ -527,8 +718,33 @@ def check_structure(root: pathlib.Path, lessons: list[Lesson]) -> list[str]:
                 problems.append(
                     f"{path}:{cell.lineno}: a predict gate is a code cell, it renders a widget"
                 )
+            if cell.directives.get("generated") and cell.source.strip():
+                problems.append(
+                    f"{path}:{cell.lineno}: a generated cell has an empty body in the source, "
+                    f"because build.py overwrites it. What is written here would be lost "
+                    f"silently, which is worse than losing it loudly"
+                )
 
-        e0_cells = [c for c in lesson.cells if c.cell_type == "code" and c.env == "E0"]
+        for kind in sorted(KNOWN_GENERATED):
+            found = [c for c in lesson.cells if c.directives.get("generated") == kind]
+            if len(found) != 1:
+                problems.append(
+                    f"{path}: {len(found)} cells with generated={kind}, every lesson has "
+                    f"exactly one"
+                )
+
+        # The bootstrap defines jvx, so a code cell above it runs against a kernel that
+        # does not have it yet. That failure reads as "the lesson is broken" to a reader
+        # who has done nothing wrong, which is the worst kind.
+        code = [c for c in lesson.cells if c.cell_type == "code"]
+        boot = [i for i, c in enumerate(code) if c.directives.get("generated") == "bootstrap"]
+        if boot and boot[0] != 0:
+            problems.append(
+                f"{path}:{code[boot[0]].lineno}: the bootstrap is not the first code cell. "
+                f"Everything above it would run before jvx exists"
+            )
+
+        e0_cells =[c for c in lesson.cells if c.cell_type == "code" and c.env == "E0"]
         if len(e0_cells) > CAP_E0_CELLS:
             problems.append(
                 f"{path}: {len(e0_cells)} tier 0 code cells, the cap is {CAP_E0_CELLS}. "
@@ -644,14 +860,14 @@ SCAFFOLD = '''\
 #   expert: null
 # ---
 
+# %% [markdown] id=badge generated=badge
+
 # %% [markdown] id=hook
 # Under 150 words, and it contains a surprise the reader can run in the next cell.
 # If there is no surprise, this is the wrong lesson or the interesting part has not
 # been found yet.
 
-# %% id=bootstrap tags=[bake] env=E0
-// Generated by build.py. Do not hand write this cell.
-jvx.banner.print()
+# %% id=bootstrap generated=bootstrap tags=[bake] env=E0
 
 # %% [markdown] id=tour
 # The prose. Where the mechanism lives, what it does, why it is that way. Every claim
@@ -714,10 +930,11 @@ def cmd_notebooks(root: pathlib.Path) -> int:
     if not lessons:
         print("no lessons yet")
         return 0
+    ctx = Context(root)
     for lesson in lessons:
         path = notebook_path(root, lesson)
         path.parent.mkdir(parents=True, exist_ok=True)
-        built = build_notebook(lesson)
+        built = build_notebook(lesson, ctx)
         before = path.read_text(encoding="utf-8") if path.is_file() else None
         if before == built:
             print(f"  unchanged  {path.relative_to(root)}")
@@ -736,10 +953,17 @@ def cmd_check(root: pathlib.Path) -> int:
         return 1
 
     problems = check_structure(root, lessons)
+    ctx = Context(root)
 
     for lesson in lessons:
         path = notebook_path(root, lesson)
-        built = build_notebook(lesson)
+        try:
+            built = build_notebook(lesson, ctx)
+        except LessonError as err:
+            # A generator that cannot run is a problem to report next to the others,
+            # not a traceback. The reader of this output is usually looking at CI.
+            problems.append(str(err))
+            continue
         if not path.is_file():
             problems.append(
                 f"{path.relative_to(root)}: not committed. Run build.py notebooks"

--- a/tools/prosecheck.py
+++ b/tools/prosecheck.py
@@ -22,9 +22,16 @@ A line ending in the comment <!-- prose-ok --> is exempt from em-dash and
 banned, which is how a document quotes a rule in order to state it.
 
 Every .md file is checked, and so are the markdown cells inside
-lessons/<id>/lesson.py, reported against their real line in that file. Lesson prose
-is the prose readers actually read, so exempting it because it lives in a .py file
-would be exempting the part that matters.
+lessons/<id>/lesson.py and the comments in jvx/*.jsh, reported against their real line
+in the file they came from. Lesson prose is the prose readers actually read, and the
+jvx comments are inlined verbatim into the bootstrap cell of every notebook, so
+exempting either because it does not live in a .md file would be exempting the part
+that matters.
+
+The wrap rule does not apply to .jsh comments. It exists so a one word change to a
+paragraph does not rewrap six lines and make the review unreadable, and that reasoning
+does not carry over to code, where wrapping a comment at a sensible width is what every
+reader expects to see.
 
 The marker rule, meaning that every claim carries [JVMS] or [HOTSPOT], is not
 checked here. It needs the lesson front matter and the claim ledger, so it lives
@@ -94,14 +101,37 @@ def markdown_of_lesson(path: pathlib.Path) -> list[tuple[int, str]]:
     return out
 
 
+def comments_of_jsh(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Pull the `//` comments out of a jvx source, keeping their real line numbers.
+
+    These are not ordinary code comments. build.py inlines every jvx source into the
+    bootstrap cell of every notebook, so a reader opening a lesson in Colab reads them
+    as the first thing on the page.
+    """
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("//"):
+            out.append((i, stripped[2:].lstrip()))
+        elif stripped.startswith("*") or stripped.startswith("/**"):
+            out.append((i, stripped.lstrip("*/ ")))
+        else:
+            out.append((i, line))
+    return out
+
+
 def numbered(path: pathlib.Path) -> list[tuple[int, str]]:
     return list(enumerate(path.read_text(encoding="utf-8").splitlines(), start=1))
 
 
 def check(path: pathlib.Path, tags: set[str], editions: set[str]) -> list[str]:
     problems: list[str] = []
+    wrap_applies = True
     if path.suffix == ".py":
         numbered_lines = markdown_of_lesson(path)
+    elif path.suffix == ".jsh":
+        numbered_lines = comments_of_jsh(path)
+        wrap_applies = False
     else:
         numbered_lines = numbered(path)
 
@@ -143,7 +173,7 @@ def check(path: pathlib.Path, tags: set[str], editions: set[str]) -> list[str]:
                     f"{found.group(1)!r}, the pin says {sorted(editions)}"
                 )
 
-        if fenced:
+        if fenced or not wrap_applies:
             continue
 
         # The wrap rule. A prose line followed by another prose line means the
@@ -172,7 +202,8 @@ def main() -> int:
         if p.is_dir():
             targets.extend(sorted(q for q in p.rglob("*.md") if ".git" not in q.parts))
             targets.extend(sorted(p.glob("lessons/*/lesson.py")))
-        elif p.suffix == ".md" or p.name == "lesson.py":
+            targets.extend(sorted(p.glob("jvx/*.jsh")))
+        elif p.suffix in {".md", ".jsh"} or p.name == "lesson.py":
             targets.append(p)
 
     root = pathlib.Path(__file__).resolve().parent.parent

--- a/tools/test_build.py
+++ b/tools/test_build.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import shutil
 import sys
 import tempfile
 import unittest
@@ -39,8 +40,12 @@ LESSON = """\
 #   expert: null
 # ---
 
+# %% [markdown] id=badge generated=badge
+
 # %% [markdown] id=hook
 # A hook with a surprise in it.
+
+# %% id=bootstrap generated=bootstrap env=E0
 
 # %% id=setup env=E0
 var x = 1;
@@ -64,6 +69,13 @@ class Harness(unittest.TestCase):
         (self.root / "docs" / "pin.json").write_text(
             json.dumps({"jdk_tag": "jdk-27+35"}), encoding="utf-8"
         )
+        repo = pathlib.Path(__file__).resolve().parent.parent
+        shutil.copytree(repo / "jvx", self.root / "jvx")
+        (self.root / "docs" / "generated").mkdir()
+        shutil.copy(
+            repo / "docs" / "generated" / "markword.json",
+            self.root / "docs" / "generated" / "markword.json",
+        )
         self.lesson_dir = self.root / "lessons" / "X01"
         (self.lesson_dir / "baked").mkdir(parents=True)
         (self.lesson_dir / "lesson.py").write_text(LESSON, encoding="utf-8")
@@ -78,6 +90,9 @@ class Harness(unittest.TestCase):
     def load(self) -> build.Lesson:
         return build.load_lesson(self.lesson_dir / "lesson.py")
 
+    def ctx(self) -> build.Context:
+        return build.Context(self.root)
+
 
 class TestParsing(Harness):
     def test_front_matter_reads_scalars_lists_and_nesting(self) -> None:
@@ -91,14 +106,14 @@ class TestParsing(Harness):
         lesson = self.load()
         self.assertEqual(
             [c.name for c in lesson.cells],
-            ["hook", "setup", "measure", "gate_1", "what_you_now_know"],
+            ["badge", "hook", "bootstrap", "setup", "measure", "gate_1", "what_you_now_know"],
         )
         self.assertEqual(lesson.cells[0].cell_type, "markdown")
-        self.assertEqual(lesson.cells[1].cell_type, "code")
+        self.assertEqual(lesson.cells[2].cell_type, "code")
 
     def test_markdown_loses_its_comment_prefix(self) -> None:
         lesson = self.load()
-        self.assertEqual(lesson.cells[0].source, "A hook with a surprise in it.")
+        self.assertEqual(lesson.cells[1].source, "A hook with a surprise in it.")
 
     def test_an_unknown_directive_is_rejected(self) -> None:
         self.write(LESSON.replace("id=setup env=E0", "id=setup enviroment=E0"))
@@ -140,17 +155,17 @@ class TestParsing(Harness):
 class TestBuild(Harness):
     def test_three_builds_are_byte_identical(self) -> None:
         lesson = self.load()
-        outputs = {build.build_notebook(lesson) for _ in range(3)}
+        outputs = {build.build_notebook(lesson, self.ctx()) for _ in range(3)}
         self.assertEqual(len(outputs), 1)
 
     def test_a_rebuilt_notebook_is_valid_json_and_nbformat_4_5(self) -> None:
-        notebook = json.loads(build.build_notebook(self.load()))
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
         self.assertEqual(notebook["nbformat"], 4)
         self.assertEqual(notebook["nbformat_minor"], 5)
-        self.assertEqual(len(notebook["cells"]), 5)
+        self.assertEqual(len(notebook["cells"]), 7)
 
     def test_cell_ids_are_unique_and_shaped_for_nbformat(self) -> None:
-        notebook = json.loads(build.build_notebook(self.load()))
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
         ids = [c["id"] for c in notebook["cells"]]
         self.assertEqual(len(ids), len(set(ids)))
         for cell_id in ids:
@@ -160,38 +175,38 @@ class TestBuild(Harness):
         doubled = LESSON + "\n# %% id=setup_again env=E0\nvar x = 1;\n"
         doubled = doubled.replace("# %% id=setup_again env=E0", "# %% env=E0")
         self.write(doubled)
-        notebook = json.loads(build.build_notebook(self.load()))
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
         ids = [c["id"] for c in notebook["cells"]]
         self.assertEqual(len(ids), len(set(ids)))
 
     def test_an_unchanged_cell_keeps_its_id_when_another_cell_changes(self) -> None:
         before = {
             c["metadata"].get("jvx_id"): c["id"]
-            for c in json.loads(build.build_notebook(self.load()))["cells"]
+            for c in json.loads(build.build_notebook(self.load(), self.ctx()))["cells"]
         }
         self.write(LESSON.replace("A hook with a surprise in it.", "A different hook."))
         after = {
             c["metadata"].get("jvx_id"): c["id"]
-            for c in json.loads(build.build_notebook(self.load()))["cells"]
+            for c in json.loads(build.build_notebook(self.load(), self.ctx()))["cells"]
         }
         self.assertNotEqual(before["hook"], after["hook"])
         self.assertEqual(before["setup"], after["setup"])
         self.assertEqual(before["gate_1"], after["gate_1"])
 
     def test_no_cell_carries_an_execution_count(self) -> None:
-        notebook = json.loads(build.build_notebook(self.load()))
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
         for cell in notebook["cells"]:
             if cell["cell_type"] == "code":
                 self.assertIsNone(cell["execution_count"])
 
     def test_only_a_bake_cell_gets_output(self) -> None:
-        notebook = json.loads(build.build_notebook(self.load()))
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
         by_name = {c["metadata"].get("jvx_id"): c for c in notebook["cells"]}
         self.assertEqual(by_name["setup"]["outputs"], [])
         self.assertTrue(by_name["measure"]["outputs"])
 
     def test_a_bake_cell_with_no_recording_says_so_instead_of_inventing_one(self) -> None:
-        notebook = json.loads(build.build_notebook(self.load()))
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
         by_name = {c["metadata"].get("jvx_id"): c for c in notebook["cells"]}
         text = "".join(by_name["measure"]["outputs"][0]["data"]["text/plain"])
         self.assertIn("no recording yet", text)
@@ -201,7 +216,7 @@ class TestBuild(Harness):
         (self.lesson_dir / "baked" / "measure.json").write_text(
             json.dumps(recorded), encoding="utf-8"
         )
-        notebook = json.loads(build.build_notebook(self.load()))
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
         by_name = {c["metadata"].get("jvx_id"): c for c in notebook["cells"]}
         self.assertEqual(by_name["measure"]["outputs"], recorded)
 
@@ -230,7 +245,7 @@ class TestCheck(Harness):
         text = path.read_text(encoding="utf-8")
         path.write_text(text.replace("var x = 1;", "var x = 2;"), encoding="utf-8")
         message = build.describe_drift(
-            path.read_text(encoding="utf-8"), build.build_notebook(self.load())
+            path.read_text(encoding="utf-8"), build.build_notebook(self.load(), self.ctx())
         )
         self.assertIn("setup", message)
 
@@ -285,6 +300,121 @@ class TestScaffold(Harness):
 
     def test_new_refuses_to_overwrite(self) -> None:
         self.assertEqual(build.cmd_new(self.root, "X01"), 1)
+
+
+class TestGenerated(Harness):
+    """The badge and the bootstrap are written by the build, not by the author.
+
+    That is the only way 112 lessons can be guaranteed to offer the same helper
+    surface, and it is why the checks here are mostly about the source file being
+    empty and the built file not being.
+    """
+
+    def source_of(self, kind: str) -> str:
+        notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
+        cells = [c for c in notebook["cells"] if c["metadata"].get("jvx_generated") == kind]
+        self.assertEqual(len(cells), 1, f"expected one {kind} cell")
+        return "".join(cells[0]["source"])
+
+    def test_the_bootstrap_inlines_every_jvx_source(self) -> None:
+        body = self.source_of("bootstrap")
+        for path in sorted((self.root / "jvx").glob("*.jsh")):
+            marker = f"jvx/{path.name}"
+            self.assertIn(marker, body, f"{marker} is not named in the header")
+        self.assertIn("class jvx {", body)
+        self.assertIn("class MarkWord {", body)
+        self.assertTrue(body.rstrip().endswith("jvx.banner()"))
+
+    def test_the_bit_positions_come_from_the_generated_json(self) -> None:
+        body = self.source_of("bootstrap")
+        data = json.loads(
+            (self.root / "docs" / "generated" / "markword.json").read_text(encoding="utf-8")
+        )
+        for field in data["fields"]:
+            self.assertIn(
+                f'new Field("{field["name"]}", {field["shift"]}, {field["bits"]},',
+                body,
+                f"{field['name']} is not in the bootstrap at the position the JSON gives",
+            )
+
+    def test_no_placeholder_survives_into_a_notebook(self) -> None:
+        body = self.source_of("bootstrap")
+        self.assertNotIn("@jvx:", body, "a placeholder would ship to a reader as literal text")
+
+    def test_an_unfilled_placeholder_is_an_error_rather_than_a_shrug(self) -> None:
+        (self.root / "jvx" / "99-broken.jsh").write_text(
+            "// @jvx:nothing_fills_this@\n", encoding="utf-8"
+        )
+        with self.assertRaises(build.LessonError) as caught:
+            build.build_notebook(self.load(), self.ctx())
+        self.assertIn("@jvx:nothing_fills_this@", str(caught.exception))
+
+    def test_the_badge_points_at_this_lesson(self) -> None:
+        body = self.source_of("badge")
+        self.assertIn("colab.research.google.com", body)
+        self.assertIn(f"notebooks/{self.load().id}/lesson.ipynb", body)
+        self.assertIn(self.load().front["question"], body)
+
+    def test_changing_jvx_changes_the_bootstrap_cell_id(self) -> None:
+        """A generated cell hashes what ships, not the empty placeholder.
+
+        If it hashed the source, editing jvx would change what every reader runs while
+        every cell id stayed the same, and the diff would show nothing.
+        """
+        def bootstrap_cell() -> dict:
+            notebook = json.loads(build.build_notebook(self.load(), self.ctx()))
+            return next(
+                c for c in notebook["cells"] if c["metadata"].get("jvx_generated") == "bootstrap"
+            )
+
+        before = bootstrap_cell()
+        path = self.root / "jvx" / "20-jvx.jsh"
+        path.write_text(path.read_text(encoding="utf-8") + "\n// one more line\n", encoding="utf-8")
+        after = bootstrap_cell()
+
+        self.assertNotEqual(before["id"], after["id"])
+        self.assertNotEqual(before["source"], after["source"])
+
+    def test_writing_in_a_generated_cell_is_caught(self) -> None:
+        self.write(
+            (self.lesson_dir / "lesson.py").read_text(encoding="utf-8").replace(
+                "# %% id=bootstrap generated=bootstrap env=E0\n",
+                "# %% id=bootstrap generated=bootstrap env=E0\nSystem.out.println(1);\n",
+            )
+        )
+        problems = build.check_structure(self.root, build.load_all(self.root))
+        self.assertTrue(
+            any("generated cell has an empty body" in p for p in problems), problems
+        )
+
+    def test_a_lesson_without_a_bootstrap_is_caught(self) -> None:
+        self.write(
+            (self.lesson_dir / "lesson.py").read_text(encoding="utf-8").replace(
+                "# %% id=bootstrap generated=bootstrap env=E0\n", ""
+            )
+        )
+        problems = build.check_structure(self.root, build.load_all(self.root))
+        self.assertTrue(
+            any("0 cells with generated=bootstrap" in p for p in problems), problems
+        )
+
+    def test_a_code_cell_above_the_bootstrap_is_caught(self) -> None:
+        self.write(
+            (self.lesson_dir / "lesson.py").read_text(encoding="utf-8").replace(
+                "# %% [markdown] id=hook",
+                "# %% id=too_early env=E0\nvar early = 1;\n\n# %% [markdown] id=hook",
+            )
+        )
+        problems = build.check_structure(self.root, build.load_all(self.root))
+        self.assertTrue(
+            any("not the first code cell" in p for p in problems), problems
+        )
+
+    def test_a_missing_markword_json_names_the_generator_to_run(self) -> None:
+        (self.root / "docs" / "generated" / "markword.json").unlink()
+        with self.assertRaises(build.LessonError) as caught:
+            build.build_notebook(self.load(), self.ctx())
+        self.assertIn("tools/gen_markword.py", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Every lesson needs a small amount of the same machinery: read an object header, ask the VM about a flag, say which JVM this actually is. Writing that into 112 lessons by hand is 112 chances to write it slightly differently, and then a reader who compares two lessons finds two answers.

So the build writes it. Two cells in every lesson are now generated, and the lesson source only says where they go.

```python
# %% [markdown] id=badge generated=badge

# %% id=bootstrap generated=bootstrap env=E0
```

Writing anything in the body of one of those is an error rather than a warning. The build overwrites it, and losing somebody's work quietly is worse than refusing it loudly.

## What is in the bootstrap

Everything in `jvx/`, in filename order, then `jvx.banner()`. The mark word field table inside it is filled in from `docs/generated/markword.json`, which is what #28 generates from HotSpot's own `markWord.hpp` at the pin. So no bit position is typed by hand anywhere between the header file and the reader's screen, and a field that moves upstream moves in every lesson at once.

Inlining rather than fetching a jar is deliberate. A reader who clicks a badge should not be waiting on Maven Central, and a project with no release yet should not pretend it has one. When `jvx` is published this cell becomes a `%maven` line and nothing else changes, because everything already goes through `jvx.` rather than through the classes underneath.

## What jvx does, and what it deliberately does not

It reads the mark word, decodes it against the generated table, and reads flags through `HotSpotDiagnosticMXBean`, which is supported API and reports a flag's origin as well as its value. That last part matters more than it looks: a flag that is true because it is the default and a flag that is true because somebody put it on the command line are different facts, and a lesson that confuses them teaches a local accident as a general truth.

It does not wrap JOL, or `jcmd`, or `jfr`. Watching the real tool is the point, and a wrapper is one more thing a reader has to trust.

Reading raw object memory has no supported API, and that is not an oversight. JVMS 2.7 says the JVM does not mandate any particular internal structure for objects, so there is nothing for an API to promise. jvx tries `jdk.internal.misc.Unsafe` first and falls back to `sun.misc.Unsafe`, and it does not hide which door opened. `jvx.markRoute()` says, and the banner prints it, because "where did this number come from" is a fair question about a number that came from reading memory directly.

## This was run, not asserted

Against a real JDK 27 in a real jshell:

```
java      27+35-2325  (27+35-2325)
vm        OpenJDK 64-Bit Server VM
on        Mac OS X aarch64
lessons pinned to jdk-27+35

UseCompactObjectHeaders      true       {default}
UseCompressedOops            true       {ergonomic}
ObjectAlignmentInBytes       8          {default}

mark word read through sun.misc.Unsafe (deprecated for removal, expect a warning)
```

and then, on one object:

```
0x0017af32ce32b001
00000000 00010111 10101111 00110010 11001110 00110010 10110000 00000001

00000000 00010111 101011.. ........ ........ ........ ........ ........  klass
........ ........ ......11 00110010 11001110 00110010 10110... ........  hash
........ ........ ........ ........ ........ ........ .....000 0.......  valhalla
........ ........ ........ ........ ........ ........ ........ .0000...  age
........ ........ ........ ........ ........ ........ ........ .....0..  self_fwd
........ ........ ........ ........ ........ ........ ........ ......01  lock

bits     field     value        meaning
------------------------------------------------------------------------------
63..42   klass     0x5eb        the compressed class pointer, present only when UseCompactObjectHeaders is on
41..11   hash      0x6659c656   the identity hash, written the first time anything asks for it
10..7    valhalla  0x0          reserved for Valhalla, unused today
6..3     age       0x0          how many collections the object has survived
2..2     self_fwd  0x0          set when a collector forwarded the object in place
1..0     lock      0x1          the lock state, and whether a collector has marked or forwarded the object

lock 01, unlocked, the ordinary state
```

`System.identityHashCode` on that object returned `0x6659c656`. The decode agrees exactly.

The row of dots is not decoration. Reading a hex number and believing you know where the field boundaries are is exactly the step where people go wrong, so the output draws the boundaries.

## Two findings from testing this

**`UseCompressedClassPointers` does not exist on JDK 27.** It was in the banner's flag list because it belonged there historically. `-XX:+PrintFlagsFinal` on the pinned build has no such flag. This is why `flag()` returns null for a missing flag instead of throwing. A banner that dies because the VM moved on is a banner that stops anyone from reading anything.

**JShell installs an identity hash on every top level variable you declare.** This one is worse than it sounds and it goes straight into probe #2. The obvious explanation is the echo, since printing an object calls `toString()` which calls `hashCode()`, and that is real, but it is not the whole story. The hash appears even with a semicolon on the end and even in quiet mode. Three cases, same session:

```
A same snippet, never a jshell var : hash 0x0
B top level var, read next snippet  : hash 0x6504e3b2
C hidden inside an array            : hash 0x0
```

So it is the variable machinery, not the display. An object that becomes a JShell variable has had its header written to before you get to look at it, and the "before" state of the thing you were about to study is gone.

That is not a small problem for a lesson about object headers, and it is exactly the class of distortion #2 exists to find. `jvx.freshMark()` is the answer for the "before" measurement: it allocates and reads in one method and never lets the reference out, so nothing can touch it. The comment above it explains the trap, since a reader who hits this on their own would have no way of guessing.

## Also here

`prosecheck` now reads the comments out of `jvx/*.jsh`. They are inlined verbatim into the bootstrap cell of every notebook, so they are the first prose a reader sees, and exempting them because they do not live in a `.md` file would exempt the part that matters. The wrap rule is the one exception, because hard wrapping a code comment is what every reader expects and that rule exists to keep prose diffs readable rather than to forbid wrapping.

Ten new tests, forty one in total. The generated cell tests copy the real `jvx/` and the real `markword.json` into the harness rather than using a fixture, so they build against what actually ships. One of them checks that changing a `jvx` source changes the bootstrap cell's id, because a generated cell hashes what ships rather than the empty placeholder, and if it did not then editing jvx would change what every reader runs while the diff showed nothing.

The Colab badge domain is excluded in `lychee.toml`. A badge points at the notebook's path on `main`, which on the pull request that adds the lesson does not exist yet, so the link is correct and unresolvable at the same time. That the path is right is checked in `test_build.py` instead, which can check it without asking Google.

Groundwork for #12.
