### PR TITLE
refcheck: resolve every source citation against the pinned tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           python tools/test_gen_sa_types.py
           python tools/test_gen_hsdis.py
           python tools/test_gen_section2.py
+          python tools/test_refcheck.py
           python tools/test_fetch_jdk.py
       - name: rebuild and compare
         run: python tools/build.py check
@@ -181,12 +182,13 @@ jobs:
           fi
 
   # Numbers that came out of HotSpot's own headers have to keep coming out of
-  # them. This is a separate job from the notebooks one on purpose: it is the
-  # only thing in CI that reaches out to openjdk/jdk, so when GitHub's raw host
-  # has a bad minute the failure says "the generated file check could not reach
-  # upstream" instead of quietly discrediting the determinism check next door.
+  # them, and lines this repository points at have to keep saying what they said.
+  # This is a separate job from the notebooks one on purpose: it is the only
+  # thing in CI that reaches out to openjdk/jdk, so when GitHub's raw host has a
+  # bad minute the failure says "the check could not reach upstream" instead of
+  # quietly discrediting the determinism check next door.
   generated:
-    name: generated files match HotSpot
+    name: generated files and citations match HotSpot
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
@@ -196,10 +198,24 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
+      # Keyed on the pin, because what is cached is source files at an immutable
+      # tag. A tag never moves, so a hit is always correct, and moving the pin is
+      # exactly when the cache should be thrown away and every citation refetched.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/jvx/src
+          key: jdk-src-${{ runner.os }}-${{ hashFiles('docs/pin.json') }}
       - name: unit tests
         run: python tools/test_gen_markword.py
       - name: the mark word layout is still what is committed
         run: python tools/gen_markword.py --check
+      # Every path:line@tag in the repository, resolved against the tree at the tag
+      # it names, with the cited line and two either side hashed into
+      # docs/citations.json. A line number that drifts is obvious to a reader. A
+      # line number that still exists and now says something else is not, and this
+      # is the only thing that catches it.
+      - name: every source citation still says what it said
+        run: python tools/refcheck.py --report
 
   # Workflow files get the same treatment as everything else here. actionlint
   # catches the shell and expression mistakes, zizmor catches the security ones,
@@ -266,8 +282,10 @@ jobs:
   #                        patches/ and vendor/, glossary uniqueness. The
   #                        directives, the caps and the requires DAG are already
   #                        in the notebooks job above
-  #     refcheck      4m   every path:line@tag against the pinned tree's hashes,
-  #                        every JVMS section reference against the section index
+  #     refcheck      4m   every JVMS section reference against a section index.
+  #                        The source citation half already runs in the generated
+  #                        job above and folds into this one when the spec half
+  #                        exists
   #     markers       1m   rule 7: every claim carries [JVMS] or [HOTSPOT], and
   #                        at most two unobservable claims per lesson
   #     bpc           6m   bpc build then bpc check, so no generated blueprint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,18 @@ export JAVA_HOME=$(python tools/fetch_jdk.py)
 
 It reads the URL and the SHA256 out of `docs/pin.json`, checks the download against the hash before unpacking anything, installs into `~/.cache/jvx` and prints the path. A hash that does not match is a hard stop with nothing unpacked. Running it again when the right build is already there does nothing and still prints the path, so it is safe in a script. Use `--dir` to put it somewhere else and `--where` to ask where it would go without installing.
 
-Citations come in two forms and CI resolves both.
+Citations come in two forms. CI resolves the first and lists the second as unchecked.
 
 ```
-src/hotspot/share/oops/markWord.hpp:48@jdk-27+35
+src/hotspot/share/oops/markWord.hpp:152@jdk-27+35
 JVMS §5.4.3.1@SE25
 ```
 
-A source citation is resolved against the pinned tree and the surrounding lines are hashed, so a citation that still points at a line whose content changed is caught. That is the failure mode that matters, because a line number that drifts is obvious and a line number that still exists and now says something different is not. A specification citation is resolved against a stored section index and the quoted fragment has to appear in the section, which catches the most common error in JVM writing: attributing a claim to the specification that the specification does not make.
+`tools/refcheck.py` resolves a source citation against the tree at the tag it names, and hashes the cited line with two lines either side into `docs/citations.json`. So a citation that still points at a line whose content changed is caught. That is the failure mode that matters, because a line number that drifts is obvious and a line number that still exists and now says something different is not. Run `python tools/refcheck.py --update` when you add a citation, and read the diff before you commit it: the ledger is where a wrong citation gets frozen if nobody looks.
+
+The ledger is keyed on the file and line without the tag, which is what makes the check bite. A tag never moves, so resolving a citation against the tag it was written for can only ever succeed. When the pin moves, every citation has to be rewritten to the new tag, because prosecheck only accepts tags the pin names, and at that point every one of them is re resolved against the new tree and the ones whose content changed come out as a list. That list is the cost of the version bump, measured rather than guessed, which is the question [M6](https://github.com/tamnd/jvm-internals/issues/19) exists to answer.
+
+A specification citation is not resolved yet. `refcheck` prints every one of them as unchecked and says how many there were, so the number cannot quietly grow while the guide claims otherwise. Resolving one means a stored section index and a check that the quoted fragment appears in the section, which is what catches the most common error in JVM writing: attributing a claim to the specification that the specification does not make. That is worth doing and it is not done, so until it is, a `[JVMS]` marker is checked by a human reading the section.
 
 The specification edition is `SE25`, and it does not describe the class files the pinned `javac` writes. That is measured rather than assumed. The pinned compiler writes class file major version 71, JVMS SE25 covers 45 through 69, and the newest published edition, SE26 from March 2026, covers 45 through 70. No published edition describes a JDK 27 class file, because that edition is published with JDK 27 itself. So the pin carries two numbers, `jdk_class_file_major` and `jvms_class_file_major`, to keep the gap visible instead of averaging it into one field, and a lesson that reads the four bytes after the magic number cannot yet cite an edition that lists what it finds there. [Issue #34](https://github.com/tamnd/jvm-internals/issues/34) tracks the move, which happens with the pin move to `jdk-27-ga` rather than before it, because the edition to move to does not exist yet. The one specification claim in the repository today is JVMS §2.7 on the representation of objects, and its number, its title and the sentence quoted from it are the same in SE25 and in SE26, which is the available evidence that the move will be a re resolve rather than a rewrite.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The JIT lessons can show instructions. [A disassembler for the JIT lessons](docs
 
 And the first generated blueprint section exists. [Emitting a section 2 that nobody transcribed](docs/probes/section2.md) turns those three measurements into [the object header's data structures section](docs/generated/section2-object-header.md) for `markWord`, `oopDesc`, `Klass` and `InstanceKlass`. It takes three sources because no one of them has the whole layout, it states the flags the layout is contingent on before it states the layout, and it refuses to write anything if the mark word does not tile 64 bits, if a field lies outside the struct that declares it or if a subclass starts inside its superclass.
 
+And every line this repository points at is checked. `tools/refcheck.py` resolves all sixteen source citations against the OpenJDK tree at the tag each one names, and hashes the cited line with two lines either side into [a committed ledger](docs/citations.json). A line number that drifts is obvious to a reader, and a line number that still exists and now says something different is not, so the hash is the part that matters. The first run of it found a citation in the contributing guide pointing at a row of dashes, which is the kind of thing a checker exists to find. Specification citations are not resolved yet, and rather than let that hide, the check prints each one as unchecked and says how many there were.
+
 See the [milestone issues](https://github.com/tamnd/jvm-internals/issues?q=is%3Aissue+label%3Akind%2Fmilestone) for the plan and [ROADMAP.md](ROADMAP.md) for the short version.
 
 ## Licence

--- a/docs/citations.json
+++ b/docs/citations.json
@@ -1,0 +1,162 @@
+{
+  "accepted_tags": [
+    "jdk-27+35",
+    "jdk-27-ga"
+  ],
+  "citations": {
+    "src/hotspot/share/oops/instanceKlass.cpp:1084": {
+      "cited_at": [
+        "CONTRIBUTING.md:40"
+      ],
+      "context_sha256": "4fc27387c7f557a44f13d727c56b3599a33e2e2a3fdd078590d5524b01315f46",
+      "line": "      // also does loader constraint checking",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:116": {
+      "cited_at": [
+        "docs/generated/markword.json:20"
+      ],
+      "context_sha256": "44e9b7dfd17a7a083d3f99b81701d3a01e6da9a962b894e395edda723816b6df",
+      "line": "  static const int lock_bits                      = 2;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:117": {
+      "cited_at": [
+        "docs/generated/markword.json:31"
+      ],
+      "context_sha256": "aa2a8c45a969552befbc661fafd638c3abfcb1b57c9716988b870e0c86642172",
+      "line": "  static const int self_fwd_bits                  = 1;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:118": {
+      "cited_at": [
+        "docs/generated/markword.json:42"
+      ],
+      "context_sha256": "64caa69868fb429eb4c1af59fae52ac768bf66e95c435d8a8edc9aede19855c3",
+      "line": "  static const int age_bits                       = 4;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:119": {
+      "cited_at": [
+        "docs/generated/markword.json:53"
+      ],
+      "context_sha256": "e2dd66005b551811094dfcc419da3c9ad54089e656b0cb56502176d4202595c2",
+      "line": "  static const int valhalla_reserved_bits         = LP64_ONLY(4) NOT_LP64(0);",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:121": {
+      "cited_at": [
+        "docs/generated/markword.json:64"
+      ],
+      "context_sha256": "1530a1f27cb055ef04a5cb575315c51fc7fce7434e9831fbfcb48e8b4f05b374",
+      "line": "  static const int hash_bits                      = max_hash_bits > 31 ? 31 : max_hash_bits;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:124": {
+      "cited_at": [
+        "docs/generated/section2-object-header.md:25",
+        "lessons/O01/lesson.py:80",
+        "lessons/O01/claims.json:51",
+        "docs/generated/markword.json:19"
+      ],
+      "context_sha256": "325fbd6c17f6202fd67039598ace1c89e3f036a45c1e83feb8ac2977c6fe90be",
+      "line": "  static const int lock_shift                     = 0;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:125": {
+      "cited_at": [
+        "docs/generated/section2-object-header.md:26",
+        "docs/generated/markword.json:30"
+      ],
+      "context_sha256": "d956646add4ebf02c04e736ff628b8e7dce5ee79a7238b7c574f2a0998791389",
+      "line": "  static const int self_fwd_shift                 = lock_shift + lock_bits;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:126": {
+      "cited_at": [
+        "docs/generated/section2-object-header.md:27",
+        "lessons/O01/lesson.py:80",
+        "lessons/O01/claims.json:69",
+        "docs/generated/markword.json:41"
+      ],
+      "context_sha256": "8b94829ec67255ccc144963d46f24029fdeafd8cd9834a603b5111e78187af1f",
+      "line": "  static const int age_shift                      = self_fwd_shift + self_fwd_bits;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:127": {
+      "cited_at": [
+        "docs/generated/section2-object-header.md:28",
+        "docs/generated/markword.json:52"
+      ],
+      "context_sha256": "d943ba4c108d146c558365f188256297617faf42eaaeb786d26445e5476a0aa5",
+      "line": "  static const int valhalla_reserved_shift        = age_shift + age_bits;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:128": {
+      "cited_at": [
+        "docs/generated/section2-object-header.md:29",
+        "lessons/O01/lesson.py:80",
+        "lessons/O01/claims.json:60",
+        "lessons/O01/claims.json:87",
+        "docs/generated/markword.json:63"
+      ],
+      "context_sha256": "50f3a5ad3608b5da4f55f0f5988b20ff250d6a58ed8385fcb55260795a312b7a",
+      "line": "  static const int hash_shift                     = valhalla_reserved_shift + valhalla_reserved_bits;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:150": {
+      "cited_at": [
+        "docs/generated/section2-object-header.md:30",
+        "lessons/O01/lesson.py:82",
+        "lessons/O01/lesson.py:325",
+        "lessons/O01/claims.json:14",
+        "lessons/O01/claims.json:78",
+        "docs/generated/markword.json:74"
+      ],
+      "context_sha256": "529a3ada39af136ad2c47779808bae4a60a1393e6adc9b0f6584756dbb0cdcbe",
+      "line": "  static constexpr int klass_shift                = hash_shift + hash_bits;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:152": {
+      "cited_at": [
+        "CONTRIBUTING.md:22",
+        "docs/generated/markword.json:75"
+      ],
+      "context_sha256": "fb0035b29dc0b6a298db2b77a495df136b19d863731c578cd8bbf6c0f6c0e7ab",
+      "line": "  static constexpr int klass_bits                 = 22;",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:43": {
+      "cited_at": [
+        "lessons/O01/claims.json:23",
+        "lessons/O01/claims.json:41",
+        "docs/generated/markword.json:103"
+      ],
+      "context_sha256": "a17c3a09b672cbad3ce42f790c93ae49c8778b4267d563caf26f3f8d6ec01081",
+      "line": "//  64 bits (without compact headers):",
+      "tag": "jdk-27+35"
+    },
+    "src/hotspot/share/oops/markWord.hpp:47": {
+      "cited_at": [
+        "lessons/O01/claims.json:32",
+        "docs/generated/markword.json:104"
+      ],
+      "context_sha256": "a8956b6e38f097bb6767975ca006d98afe060788b7747cc7a560b564ab6e3f01",
+      "line": "//  64 bits (with compact headers):",
+      "tag": "jdk-27+35"
+    },
+    "src/utils/hsdis/README.md:73": {
+      "cited_at": [
+        "docs/generated/hsdis.md:132",
+        "docs/probes/hsdis.md:11"
+      ],
+      "context_sha256": "6f3bc98b702db25935505b3eae2dde82df3b4230a2aa2e1f7c3164fdd4051729",
+      "line": "**NOTE:** If you do this using the binutils backend, the resulting build may not",
+      "tag": "jdk-27+35"
+    }
+  },
+  "context_lines": 2,
+  "generated_by": "tools/refcheck.py --update",
+  "note": "Keyed on path:line without the tag, so that moving the pin re-resolves every citation against the new tree and the ones whose content changed come out as a list. That list is the cost of the version bump.",
+  "updated": "2026-09-05"
+}

--- a/tools/refcheck.py
+++ b/tools/refcheck.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Resolve every source citation in the repository against the pinned tree.
+
+`CONTRIBUTING.md` promises this: "A source citation is resolved against the pinned tree
+and the surrounding lines are hashed, so a citation that still points at a line whose
+content changed is caught. That is the failure mode that matters, because a line number
+that drifts is obvious and a line number that still exists and now says something
+different is not." This is the thing that keeps that promise.
+
+  python tools/refcheck.py            resolve every citation against the ledger
+  python tools/refcheck.py --update   rewrite the ledger from the pinned tree
+  python tools/refcheck.py --offline  use only what is already cached
+
+The ledger is `docs/citations.json`. It records, for each cited line, the tag it was
+resolved at, the text of the line, and a hash of the line with two lines of context
+either side. The ledger is keyed on `path:line` without the tag, on purpose. A tag is
+immutable, so checking a citation against the tag it was written for can never fail and
+would be a check that cannot catch anything. Keying without the tag means that when the
+pin moves, every citation is re-resolved against the new tree and the ones whose content
+changed come out as a list. That list is the cost of the version bump, measured rather
+than estimated, which is what M6 (issue #19) exists to find out.
+
+Source files are fetched from raw.githubusercontent.com at the pinned tag and cached
+under `~/.cache/jvx/src/<tag>/`. A tag never moves, so the cache never needs to expire.
+Set `JVX_JDK_SRC` to a checkout to use that instead of the network, which is what a
+machine that has already cloned the JDK should do.
+
+Specification citations are not resolved here yet. Resolving one means an index of the
+sections of a specification edition, which is a different source, a different fetch and a
+different failure mode, so it is its own piece of work. This one refuses to pretend it
+checked them: `--report` prints every one of them as unchecked, and the closing line says
+how many went unchecked so the number cannot quietly grow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+LEDGER = pathlib.Path("docs/citations.json")
+RAW = "https://raw.githubusercontent.com/openjdk/jdk/{tag}/{path}"
+CACHE = pathlib.Path(os.environ.get("JVX_CACHE",
+                                    pathlib.Path.home() / ".cache" / "jvx")) / "src"
+
+# The same two forms prosecheck matches, because a citation the two tools disagree about
+# is a citation one of them is not checking.
+SOURCE_CITE = re.compile(
+    r"([A-Za-z0-9_/.$-]+\.(?:cpp|hpp|c|h|java|ad|xml|md)):(\d+)@(\S+?)(?=[\s)\]}.,;`\"']|$)")
+SPEC_CITE = re.compile(r"(?:JVMS|JLS)\s*[^@\s]*@(\S+?)(?=[\s)\]}.,;`\"']|$)")
+
+# Where citations live. Prose, lesson markdown and jvx comments are what prosecheck
+# reads. The two JSON shapes are here as well because a claim ledger and a generated
+# layout both carry citations, and a citation nobody resolves is the whole problem.
+PROSE = ("*.md",)
+JSON_WITH_CITATIONS = ("lessons/*/claims.json", "docs/generated/*.json")
+
+# How much of the file around the cited line goes into the hash. Two either side is
+# enough to catch an edit that moved the meaning without moving the line number, and
+# small enough that an unrelated edit six lines away does not cry wolf.
+CONTEXT = 2
+
+# A line ending in this is a citation being described rather than made. The format has to
+# be documented somewhere, and the document that describes it cannot be the one file the
+# checker is not allowed to read.
+ALLOW = "<!-- refcheck-ok -->"
+
+
+def load_pin() -> dict:
+    return json.loads((ROOT / "docs" / "pin.json").read_text(encoding="utf-8"))
+
+
+def sources() -> list[pathlib.Path]:
+    """Every file a citation can live in, as a repository relative path."""
+    found: list[pathlib.Path] = []
+    for path in sorted(ROOT.rglob("*.md")):
+        if ".git" not in path.parts:
+            found.append(path)
+    for pattern in ("lessons/*/lesson.py", "jvx/*.jsh"):
+        found.extend(sorted(ROOT.glob(pattern)))
+    for pattern in JSON_WITH_CITATIONS:
+        found.extend(sorted(ROOT.glob(pattern)))
+    return found
+
+
+def cited(paths: list[pathlib.Path]) -> tuple[dict[str, dict], list[dict]]:
+    """Every source citation, and every specification citation, with where each was made.
+
+    Keyed on `path:line`, with the tags collected as a set rather than folded into the
+    key. Two citations of one line at two different tags is a thing worth seeing, and a
+    key that included the tag would hide it by making them two unrelated entries.
+
+    JSON files are read as text rather than parsed, because a citation is a citation
+    whatever key it sits under and a parser that only looked at the keys it knew about
+    would quietly stop checking the day somebody added a field.
+    """
+    source: dict[str, dict] = {}
+    spec: list[dict] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for number, line in enumerate(text.splitlines(), start=1):
+            if ALLOW in line:
+                continue
+            where = f"{path.relative_to(ROOT)}:{number}"
+            for found in SOURCE_CITE.finditer(line):
+                key = f"{found.group(1)}:{found.group(2)}"
+                entry = source.setdefault(key, {"cited_at": [], "tags": []})
+                if where not in entry["cited_at"]:
+                    entry["cited_at"].append(where)
+                if found.group(3) not in entry["tags"]:
+                    entry["tags"].append(found.group(3))
+            for found in SPEC_CITE.finditer(line):
+                spec.append({"edition": found.group(1), "where": where,
+                             "text": found.group(0)})
+    return source, spec
+
+
+def fetch(path: str, tag: str, offline: bool) -> list[str] | None:
+    """One file from the pinned tree, cached, as a list of lines without their endings."""
+    local = os.environ.get("JVX_JDK_SRC")
+    if local:
+        on_disk = pathlib.Path(local) / path
+        if not on_disk.is_file():
+            return None
+        return on_disk.read_text(encoding="utf-8", errors="replace").splitlines()
+
+    cached = CACHE / tag / path
+    if not cached.is_file():
+        if offline:
+            return None
+        url = RAW.format(tag=urllib.parse.quote(tag, safe=""), path=path)
+        try:
+            with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+                body = response.read()
+        except OSError as failure:
+            print(f"could not fetch {url}: {failure}", file=sys.stderr)
+            return None
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        cached.write_bytes(body)
+    return cached.read_text(encoding="utf-8", errors="replace").splitlines()
+
+
+def resolve(key: str, tag: str, offline: bool) -> dict:
+    """What the pinned tree says at one cited line."""
+    path, _, number = key.rpartition(":")
+    line = int(number)
+    body = fetch(path, tag, offline)
+    if body is None:
+        return {"resolved": False, "why": f"could not read {path} at {tag}"}
+    if line < 1 or line > len(body):
+        return {"resolved": False,
+                "why": f"{path} at {tag} has {len(body)} lines and the citation is to {line}"}
+    window = body[max(0, line - 1 - CONTEXT):line + CONTEXT]
+    digest = hashlib.sha256(
+        "\n".join(text.rstrip() for text in window).encode("utf-8")).hexdigest()
+    return {"resolved": True, "tag": tag, "line": body[line - 1].rstrip(),
+            "context_sha256": digest, "file_lines": len(body)}
+
+
+def ledger() -> dict:
+    path = ROOT / LEDGER
+    if not path.is_file():
+        return {"citations": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build(source: dict[str, dict], accepted: list[str],
+          offline: bool) -> tuple[dict, list[str]]:
+    """Resolve every citation and return the new ledger, plus what could not be resolved.
+
+    Each citation is resolved against the tag it names rather than against the pin, so
+    that a citation written at the GA tag is checked against the GA tree. The tag still
+    has to be one the pin accepts, which is what stops a citation naming a tag that says
+    whatever the author wished it said.
+    """
+    entries: dict[str, dict] = {}
+    unresolved: list[str] = []
+    for key in sorted(source):
+        tags = source[key]["tags"]
+        where = ", ".join(source[key]["cited_at"])
+        if len(tags) > 1:
+            unresolved.append(
+                f"{key} is cited at more than one tag ({', '.join(tags)}), at {where}. "
+                f"One line cannot be two lines. Pick the tag the prose is written for.")
+            continue
+        tag = tags[0]
+        if tag not in accepted:
+            unresolved.append(
+                f"{key} names the tag {tag}, which docs/pin.json does not accept "
+                f"({', '.join(accepted)}), at {where}")
+            continue
+        found = resolve(key, tag, offline)
+        if not found["resolved"]:
+            unresolved.append(f"{key}: {found['why']}, cited at {where}")
+            continue
+        entries[key] = {
+            "tag": found["tag"],
+            "line": found["line"],
+            "context_sha256": found["context_sha256"],
+            "cited_at": source[key]["cited_at"],
+        }
+    return entries, unresolved
+
+
+def compare(known: dict, entries: dict, source: dict[str, dict]) -> list[str]:
+    """Everything that changed between the ledger and the tree, in words."""
+    problems: list[str] = []
+    for key in sorted(entries):
+        was = known.get(key)
+        now = entries[key]
+        where = ", ".join(source[key]["cited_at"])
+        if was is None:
+            problems.append(
+                f"{key} is cited at {where} and is not in the ledger. "
+                f"Run tools/refcheck.py --update and read the diff before committing it.")
+            continue
+        if was["context_sha256"] != now["context_sha256"]:
+            problems.append(
+                f"{key} resolved at {now['tag']} but its content changed. The ledger has "
+                f"{was['line']!r} at {was['tag']} and the tree has {now['line']!r}. "
+                f"Cited at {where}. Read the new tree and move the citation or fix the "
+                f"prose, then run --update.")
+            continue
+        if was["cited_at"] != now["cited_at"]:
+            problems.append(
+                f"{key} is cited in different places than the ledger records: "
+                f"{was['cited_at']} became {now['cited_at']}. Run --update.")
+    for key in sorted(set(known) - set(entries)):
+        problems.append(
+            f"{key} is in the ledger and is cited nowhere. Run --update to drop it.")
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--update", action="store_true", help="rewrite the ledger")
+    ap.add_argument("--offline", action="store_true",
+                    help="use the cache and a local checkout only, fetch nothing")
+    ap.add_argument("--report", action="store_true",
+                    help="print what was checked and what was not")
+    args = ap.parse_args(argv)
+
+    pin = load_pin()
+    accepted = [pin[key] for key in ("jdk_tag", "jdk_ga_tag") if pin.get(key)]
+    files = sources()
+    source, spec = cited(files)
+    if not source:
+        print("no source citations found, which cannot be right", file=sys.stderr)
+        return 1
+
+    entries, unresolved = build(source, accepted, args.offline)
+
+    if args.update:
+        written = {
+            "generated_by": "tools/refcheck.py --update",
+            "updated": datetime.datetime.now(datetime.UTC).date().isoformat(),
+            "accepted_tags": accepted,
+            "context_lines": CONTEXT,
+            "note": (
+                "Keyed on path:line without the tag, so that moving the pin re-resolves "
+                "every citation against the new tree and the ones whose content changed "
+                "come out as a list. That list is the cost of the version bump."
+            ),
+            "citations": entries,
+        }
+        (ROOT / LEDGER).write_text(
+            json.dumps(written, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"wrote {LEDGER}: {len(entries)} citations")
+        if unresolved:
+            for line in unresolved:
+                print(f"unresolved: {line}", file=sys.stderr)
+            return 1
+        return 0
+
+    problems = compare(ledger().get("citations", {}), entries, source)
+    for line in unresolved:
+        problems.append(f"unresolved: {line}")
+
+    if args.report or problems:
+        print(f"{len(source)} source citations in {len(files)} files, resolved against "
+              f"{' and '.join(accepted)}")
+        print(f"{len(spec)} specification citations, not checked here: they need a "
+              f"section index and are their own piece of work")
+        for citation in spec:
+            print(f"  unchecked  {citation['text']}  at {citation['where']}")
+
+    for line in problems:
+        print(f"refcheck: {line}", file=sys.stderr)
+    if problems:
+        return 1
+    print(f"refcheck: {len(entries)} source citations resolve and none has drifted, "
+          f"{len(spec)} specification citations unchecked")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/test_refcheck.py
+++ b/tools/test_refcheck.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Tests for the citation resolver.
+
+A checker that passes when it should fail is worse than no checker, because it turns a
+promise in `CONTRIBUTING.md` into a promise the repository appears to keep. So most of
+these build a citation that is wrong in a specific way and check that refcheck says so:
+a line whose content changed under a stable line number, a line past the end of the file,
+a tag the pin does not accept, one line cited at two tags, an entry in the ledger nobody
+cites any more.
+
+The rest hold the reading half honest. The scanner has to find a citation in prose, in a
+lesson, in a claims file and in generated JSON, because a citation nobody reads is a
+citation nobody checks, and the four places citations live in this repository are four
+different file formats. The network is never touched: every test either points
+`JVX_JDK_SRC` at a tree made in a temporary directory or drives the functions directly.
+
+The last one is the one that matters on a normal day. It resolves every citation in the
+repository against the committed ledger, which is what CI runs.
+
+  python tools/test_refcheck.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import refcheck  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+TAG = "jdk-27+35"
+OTHER = "jdk-27-ga"
+FILE = "src/hotspot/share/oops/markWord.hpp"
+
+# Enough of a header to cite into. The lines either side of the cited one are here
+# because the hash covers them, and a test that could not tell a changed neighbour from a
+# changed line would not be testing the thing the hash is for.
+HEADER = """\
+// line one
+// line two
+  static const int lock_bits = 2;
+// line four
+// line five
+  static const int age_bits = 4;
+// line seven
+"""
+
+
+@contextlib.contextmanager
+def tree(text: str = HEADER):
+    """A checkout with one file in it, with JVX_JDK_SRC pointed at it."""
+    with tempfile.TemporaryDirectory() as where:
+        path = pathlib.Path(where) / FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        was = os.environ.get("JVX_JDK_SRC")
+        os.environ["JVX_JDK_SRC"] = where
+        try:
+            yield pathlib.Path(where)
+        finally:
+            if was is None:
+                del os.environ["JVX_JDK_SRC"]
+            else:
+                os.environ["JVX_JDK_SRC"] = was
+
+
+def one(line: int = 3, tag: str = TAG, where: str = "docs/a.md:1") -> dict:
+    return {f"{FILE}:{line}": {"cited_at": [where], "tags": [tag]}}
+
+
+class TestResolving(unittest.TestCase):
+    def test_a_citation_resolves_to_the_line_it_names(self):
+        with tree():
+            found = refcheck.resolve(f"{FILE}:3", TAG, offline=True)
+        self.assertTrue(found["resolved"])
+        self.assertEqual(found["line"], "  static const int lock_bits = 2;")
+
+    def test_a_line_past_the_end_of_the_file_is_refused(self):
+        with tree():
+            found = refcheck.resolve(f"{FILE}:400", TAG, offline=True)
+        self.assertFalse(found["resolved"])
+        self.assertIn("has 7 lines", found["why"])
+
+    def test_a_file_that_is_not_in_the_tree_is_refused(self):
+        with tree():
+            found = refcheck.resolve("src/hotspot/share/oops/nope.hpp:3", TAG,
+                                     offline=True)
+        self.assertFalse(found["resolved"])
+        self.assertIn("could not read", found["why"])
+
+    def test_the_hash_covers_the_lines_around_the_cited_one(self):
+        """The whole point. A neighbour changing has to change the hash."""
+        with tree():
+            before = refcheck.resolve(f"{FILE}:3", TAG, offline=True)
+        moved = HEADER.replace("// line five", "// line five, edited")
+        with tree(moved):
+            after = refcheck.resolve(f"{FILE}:3", TAG, offline=True)
+        self.assertEqual(before["line"], after["line"])
+        self.assertNotEqual(before["context_sha256"], after["context_sha256"])
+
+    def test_an_edit_six_lines_away_does_not_change_the_hash(self):
+        """The other half. A hash that changes on every edit is a hash nobody trusts."""
+        with tree():
+            before = refcheck.resolve(f"{FILE}:3", TAG, offline=True)
+        with tree(HEADER.replace("// line seven", "// line seven, edited")):
+            after = refcheck.resolve(f"{FILE}:3", TAG, offline=True)
+        self.assertEqual(before["context_sha256"], after["context_sha256"])
+
+    def test_trailing_whitespace_is_not_a_content_change(self):
+        with tree():
+            before = refcheck.resolve(f"{FILE}:3", TAG, offline=True)
+        with tree(HEADER.replace("lock_bits = 2;", "lock_bits = 2;   ")):
+            after = refcheck.resolve(f"{FILE}:3", TAG, offline=True)
+        self.assertEqual(before["context_sha256"], after["context_sha256"])
+
+
+class TestBuilding(unittest.TestCase):
+    def test_a_tag_the_pin_does_not_accept_is_refused(self):
+        with tree():
+            entries, unresolved = refcheck.build(
+                one(tag="jdk-26+9"), [TAG, OTHER], offline=True)
+        self.assertEqual(entries, {})
+        self.assertIn("does not accept", unresolved[0])
+
+    def test_one_line_cited_at_two_tags_is_refused(self):
+        source = one()
+        source[f"{FILE}:3"]["tags"].append(OTHER)
+        with tree():
+            entries, unresolved = refcheck.build(source, [TAG, OTHER], offline=True)
+        self.assertEqual(entries, {})
+        self.assertIn("more than one tag", unresolved[0])
+
+    def test_what_could_not_be_resolved_names_where_it_was_cited(self):
+        with tree():
+            _, unresolved = refcheck.build(
+                one(line=400, where="docs/probes/thing.md:12"), [TAG], offline=True)
+        self.assertIn("docs/probes/thing.md:12", unresolved[0])
+
+
+class TestComparing(unittest.TestCase):
+    def setUp(self):
+        self.source = one()
+        with tree():
+            self.entries, _ = refcheck.build(self.source, [TAG], offline=True)
+
+    def test_a_ledger_that_matches_the_tree_is_quiet(self):
+        self.assertEqual(refcheck.compare(self.entries, self.entries, self.source), [])
+
+    def test_a_line_whose_content_changed_is_caught(self):
+        with tree(HEADER.replace("lock_bits = 2;", "lock_bits = 3;")):
+            now, _ = refcheck.build(self.source, [TAG], offline=True)
+        problems = refcheck.compare(self.entries, now, self.source)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("its content changed", problems[0])
+        self.assertIn("lock_bits = 2;", problems[0])
+        self.assertIn("lock_bits = 3;", problems[0])
+
+    def test_a_citation_that_is_not_in_the_ledger_is_caught(self):
+        problems = refcheck.compare({}, self.entries, self.source)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("not in the ledger", problems[0])
+
+    def test_a_ledger_entry_nobody_cites_is_caught(self):
+        stale = dict(self.entries)
+        stale["src/hotspot/share/oops/gone.hpp:1"] = {
+            "tag": TAG, "line": "x", "context_sha256": "y", "cited_at": []}
+        problems = refcheck.compare(stale, self.entries, self.source)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("cited nowhere", problems[0])
+
+    def test_a_citation_that_moved_to_another_file_is_caught(self):
+        moved = {f"{FILE}:3": {"cited_at": ["docs/b.md:9"], "tags": [TAG]}}
+        with tree():
+            now, _ = refcheck.build(moved, [TAG], offline=True)
+        problems = refcheck.compare(self.entries, now, moved)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("different places", problems[0])
+
+
+class TestScanning(unittest.TestCase):
+    """Citations live in four file formats here, and all four have to be read."""
+
+    def scan(self, name: str, body: str) -> tuple[dict, list]:
+        with tempfile.TemporaryDirectory() as where:
+            path = pathlib.Path(where) / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+            was = refcheck.ROOT
+            refcheck.ROOT = pathlib.Path(where)
+            try:
+                return refcheck.cited([path])
+            finally:
+                refcheck.ROOT = was
+
+    def test_a_citation_in_prose_is_found(self):
+        source, _ = self.scan("docs/a.md", f"The klass field is 22 bits {{[HOTSPOT {FILE}:152@{TAG}]}}.\n")
+        self.assertEqual(list(source), [f"{FILE}:152"])
+
+    def test_a_citation_in_a_claims_file_is_found(self):
+        body = json.dumps({"claims": [{"citation": f"{FILE}:152@{TAG}"}]}, indent=2)
+        source, _ = self.scan("lessons/O01/claims.json", body)
+        self.assertEqual(list(source), [f"{FILE}:152"])
+
+    def test_a_citation_in_generated_json_is_found(self):
+        body = json.dumps({"defined_at": f"{FILE}:150@{TAG}"}, indent=2)
+        source, _ = self.scan("docs/generated/markword.json", body)
+        self.assertEqual(list(source), [f"{FILE}:150"])
+
+    def test_a_citation_in_a_lesson_is_found(self):
+        source, _ = self.scan("lessons/O01/lesson.py", f"# The shift {FILE}:150@{TAG}\n")
+        self.assertEqual(list(source), [f"{FILE}:150"])
+
+    def test_one_line_cited_from_four_places_is_one_entry_with_four_places(self):
+        body = "\n".join(f"line {n} cites {FILE}:152@{TAG}" for n in range(4)) + "\n"
+        source, _ = self.scan("docs/a.md", body)
+        self.assertEqual(len(source), 1)
+        self.assertEqual(len(source[f"{FILE}:152"]["cited_at"]), 4)
+
+    def test_a_line_marked_ok_is_left_alone(self):
+        source, _ = self.scan(
+            "docs/a.md", f"Write it as path/to/file.cpp:123@{TAG} {refcheck.ALLOW}\n")
+        self.assertEqual(source, {})
+
+    def test_a_specification_citation_is_collected_and_not_resolved(self):
+        source, spec = self.scan("docs/a.md", "Objects are represented {[JVMS §2.7@SE25]}.\n")
+        self.assertEqual(source, {})
+        self.assertEqual(len(spec), 1)
+        self.assertEqual(spec[0]["edition"], "SE25")
+
+    def test_a_citation_ending_a_sentence_keeps_its_tag(self):
+        """A trailing period is punctuation and a trailing backtick is markup."""
+        for ending in (".", ")", "`", "]}.", ","):
+            with self.subTest(ending=ending):
+                source, _ = self.scan("docs/a.md", f"see {FILE}:152@{TAG}{ending}\n")
+                self.assertEqual(source[f"{FILE}:152"]["tags"], [TAG])
+
+
+class TestTheRepository(unittest.TestCase):
+    """What CI runs, and the reason the ledger is committed."""
+
+    def setUp(self):
+        self.source, self.spec = refcheck.cited(refcheck.sources())
+        self.ledger = refcheck.ledger()
+
+    def test_every_citation_in_the_repository_is_in_the_ledger(self):
+        missing = sorted(set(self.source) - set(self.ledger["citations"]))
+        self.assertEqual(missing, [], "run tools/refcheck.py --update")
+
+    def test_the_ledger_cites_nothing_that_is_not_cited(self):
+        stale = sorted(set(self.ledger["citations"]) - set(self.source))
+        self.assertEqual(stale, [], "run tools/refcheck.py --update")
+
+    def test_the_ledger_records_a_real_line_for_every_citation(self):
+        """A ledger full of blank lines would pass every other test in this file."""
+        for key, entry in self.ledger["citations"].items():
+            with self.subTest(citation=key):
+                self.assertTrue(entry["line"].strip(), "the cited line is blank")
+                self.assertEqual(len(entry["context_sha256"]), 64)
+
+    def test_every_tag_in_the_ledger_is_one_the_pin_accepts(self):
+        pin = refcheck.load_pin()
+        accepted = {pin[k] for k in ("jdk_tag", "jdk_ga_tag") if pin.get(k)}
+        for key, entry in self.ledger["citations"].items():
+            with self.subTest(citation=key):
+                self.assertIn(entry["tag"], accepted)
+
+    def test_the_repository_still_has_citations_to_check(self):
+        """Guards against a scanner that quietly stops finding anything."""
+        self.assertGreater(len(self.source), 10)
+
+    def test_the_report_says_how_many_specification_citations_went_unchecked(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            refcheck.main(["--report", "--offline"])
+        self.assertIn(f"{len(self.spec)} specification citations", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What this is

`CONTRIBUTING.md` has said "Citations come in two forms and CI resolves both" since the repository existed. Nothing resolved either one. This PR makes half of that sentence true and stops the other half from pretending.

`tools/refcheck.py` resolves every `path:line@tag` in the repository against the OpenJDK tree at the tag it names, and hashes the cited line with two lines either side into `docs/citations.json`.

```
$ python tools/refcheck.py --report
16 source citations in 29 files, resolved against jdk-27+35 and jdk-27-ga
4 specification citations, not checked here: they need a section index and are their own piece of work
  unchecked  JVMS §5.4.3.1@SE25  at CONTRIBUTING.md:23
  unchecked  JVMS §2.7@SE25  at lessons/O01/lesson.py:90
  unchecked  JVMS §2.7@SE25  at lessons/O01/lesson.py:329
  unchecked  JVMS 2.7@SE25  at lessons/O01/claims.json:6
refcheck: 16 source citations resolve and none has drifted, 4 specification citations unchecked
```

## The design decision worth arguing with

The ledger is keyed on `path:line` **without** the tag. That looks like a bug and is the whole point.

A tag is immutable. Resolving `markWord.hpp:152@jdk-27+35` against `jdk-27+35` can never fail, so a checker that keyed the ledger by tag would be a checker that cannot catch anything. It would go green forever while being useless.

Keying without the tag means the check is dormant until the pin moves. When it moves, prosecheck forces every citation to the new tag, because prosecheck only accepts tags `docs/pin.json` names. At that moment every citation is re resolved against the new tree, and the ones whose content changed come out as a list of lines this repository points at that now say something different. That list is the cost of the version bump, measured rather than guessed, which is the question M6 (#19) exists to answer.

That is also why the hash covers context. A line number that drifts is obvious to a reader, because they follow the link and land somewhere absurd. A line number that still exists and now says something else is invisible. Two lines either side, with trailing whitespace stripped, catches an edit that moved the meaning without moving the number, and ignores an edit six lines away that did not.

## What it found on its first run

`src/hotspot/share/oops/markWord.hpp:48`, cited in `CONTRIBUTING.md` as **the example of what a citation looks like**, resolves to:

```
//  -------------------------------
```

A row of dashes. The guide that tells you how to cite a line was citing a horizontal rule. Moved to `markWord.hpp:152`, which is `static constexpr int klass_bits = 22;`, a line worth pointing at. Every other citation in the repository resolves to something meaningful, which is the part I checked by reading all sixteen rather than trusting that they parsed.

## What it does not do

Specification citations. Resolving one needs a section index for a JVMS edition, which is a different source, a different fetch and a different failure mode. Rather than let the gap hide, `--report` prints every unresolved specification citation by name and the closing line says how many went unchecked, so the number cannot quietly grow. `CONTRIBUTING.md` now says plainly that a `[JVMS]` marker is checked by a human reading the section until the index exists. That is the follow up.

## Where it runs

The `generated` job, which is already the only job that reaches `openjdk/jdk`, so an upstream bad minute fails somewhere the failure message is honest about why. It gets a cache keyed on `docs/pin.json`: what is cached is source at an immutable tag, so a hit is always correct, and moving the pin is exactly when the cache should be thrown away.

The 28 unit tests are offline and run in the `notebooks` job. They point `JVX_JDK_SRC` at a tree built in a temporary directory, so nothing in the test suite touches the network.

## Tests

28 tests. The ones that matter build a citation that is wrong in a specific way and check refcheck says so:

- a line whose content changed under a stable line number
- a line past the end of the file
- a tag `docs/pin.json` does not accept
- one line cited at two different tags
- a ledger entry nobody cites any more
- a citation that moved to a different file

Two hold the hash honest in both directions: a neighbour changing has to change it, and an edit six lines away must not, because a hash that fires on everything is a hash people learn to override. Four check the scanner reads all four formats citations live in here, which are prose, a lesson, a claims file and generated JSON.

`test_the_ledger_records_a_real_line_for_every_citation` is the one guarding against the failure mode of this whole PR: a ledger full of blank lines would pass every other test in the file.

```
Ran 28 tests in 3.483s
OK
```

## Checked locally

```
prosecheck: 27 files, 0 problems
build.py check: 1 lessons, 0 problems
refcheck: 16 source citations resolve and none has drifted, 4 specification citations unchecked
```

Part of M1 (#14), which lists "refcheck and the claim ledger, both running in CI" under Ships.
